### PR TITLE
Add patch 2.5.9

### DIFF
--- a/rootfs.sh
+++ b/rootfs.sh
@@ -108,6 +108,9 @@ get_file https://ftp.gnu.org/gnu/gzip/gzip-1.2.4.tar
 # diffutils 2.7
 get_file https://ftp.gnu.org/gnu/diffutils/diffutils-2.7.tar.gz
 
+# patch 2.5.9
+get_file https://ftp.gnu.org/pub/gnu/patch/patch-2.5.9.tar.gz
+
 # General cleanup
 find tmp -name .git -exec rm -rf \;
 

--- a/sysa/after.kaem.run
+++ b/sysa/after.kaem.run
@@ -70,3 +70,10 @@ cd ..
 cd diffutils-2.7
 kaem --file ../diffutils-2.7.kaem
 cd ..
+
+# Part 12: patch
+/after/bin/gunzip patch-2.5.9.tar.gz
+/after/bin/tar xf patch-2.5.9.tar
+cd patch-2.5.9
+kaem --file ../patch-2.5.9.kaem
+cd ..

--- a/sysa/patch-2.5.9.kaem
+++ b/sysa/patch-2.5.9.kaem
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -ex
+
+# Variables
+bindir=/after/bin
+
+# Create config.h and patchlevel.h
+catm config.h
+catm patchlevel.h
+
+# Patch
+cp pch.c pch_patched.c
+sed -i 841,848d pch_patched.c
+
+# Compile
+tcc -c error.c
+tcc -c getopt.c
+tcc -c getopt1.c
+tcc -c -I. addext.c
+tcc -c -I. argmatch.c
+tcc -c -I. -DHAVE_DECL_GETENV -DHAVE_DECL_MALLOC -DHAVE_DIRENT_H -Dsize_t="unsigned long" backupfile.c
+tcc -c -I. -Dsize_t="unsigned long" basename.c
+tcc -c -I. -Dsize_t="unsigned long" dirname.c
+tcc -c -I. -DHAVE_LIMITS_H -DHAVE_GETEUID inp.c
+tcc -c -I. maketime.c
+tcc -c -I. -Dsize_t="unsigned long" partime.c
+tcc -c -I. -DHAVE_MKTEMP -DHAVE_LIMITS_H -DHAVE_GETEUID -DPACKAGE_BUGREPORT= patch.c
+tcc -c -I. -Ded_PROGRAM=\"/nullop\" -DHAVE_LIMITS_H -DHAVE_GETEUID pch_patched.c
+tcc -c -I. quote.c
+tcc -c -I. -Dmbstate_t=void -Dsize_t="unsigned long" quotearg.c
+tcc -c -I. quotesys.c
+tcc -c -I. -DRETSIGTYPE=int -Dsize_t="unsigned long" -DHAVE_MKDIR -DHAVE_RMDIR -DHAVE_LIMITS_H -DHAVE_GETEUID -DHAVE_FCNTL_H util.c
+tcc -c -I. -DPACKAGE_NAME=\"patch\" -DPACKAGE_VERSION=\"2.5.9\" version.c
+tcc -c -I. -DHAVE_MALLOC -DHAVE_REALLOC xmalloc.c
+
+# Link
+tcc -static -o ${bindir}/patch error.o getopt.o getopt1.o addext.o argmatch.o backupfile.o basename.o dirname.o inp.o maketime.o partime.o patch.o pch_patched.o quote.o quotearg.o quotesys.o util.o version.o xmalloc.o
+
+# Test
+patch --version


### PR DESCRIPTION
[DONOTMERGE]

Is currently broken, resulting binary is useless.

The resulting binary fails to patches any files, with the error:
```
patch: **** Can't create file /tmp/pojbnfcaerror 02:
```

I have determined the issue is *not* the creation of the tmpdir.