### PR TITLE
musl: Force line buffering when writing to stdout

### DIFF
--- a/sysa/musl-1.1.24/patches/stdout_force_line_buffering.patch
+++ b/sysa/musl-1.1.24/patches/stdout_force_line_buffering.patch
@@ -1,0 +1,21 @@
+SPDX-FileCopyrightText: 2021 Paul Dersey <pdersey@gmail.com>
+
+SPDX-License-Identifier: MIT
+
+Force writing to stdout to use line buffering.  Works around problem
+with pipes and redirecting stdout.
+
+--- src/stdio/__stdout_write.c
++++ src/stdio/__stdout_write.c
+@@ -5,7 +5,6 @@ size_t __stdout_write(FILE *f, const unsigned char *buf, size_t len)
+ {
+ 	struct winsize wsz;
+ 	f->write = __stdio_write;
+-	if (!(f->flags & F_SVB) && __syscall(SYS_ioctl, f->fd, TIOCGWINSZ, &wsz))
+-		f->lbf = -1;
++	f->lbf = '\n';
+ 	return __stdio_write(f, buf, len);
+ }
+-- 
+2.30.0
+


### PR DESCRIPTION
This is a workaround for an issue in which binaries compiled with our
tcc+musl toolchain can fail to write complete output when stdout is
redirected to a file or pipe.