### PR TITLE
Rebuild musl libc after building tcc-musl

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ patch `tcc` in the next step to ignore duplicate symbols.
 We recompile `tcc` against musl. This is a two stage process. First we build
 tcc-0.9.27 that itself links to Mes C library but produces binaries linked to
 musl. Then we recompile newly produced tcc with itself. Interestingly,
-tcc-0.9.27 linked against musl is self hosting.
+tcc-0.9.27 linked against musl is self hosting.  Finally, we rebuild musl once more
+with the new `tcc`.
 
 #### Part 22: m4 1.4.7
 

--- a/sysa/run.sh
+++ b/sysa/run.sh
@@ -17,6 +17,7 @@ build musl-1.1.24
 
 # Part 21
 build tcc-0.9.27 tcc-musl.sh
+build musl-1.1.24
 
 # Part 22
 build m4-1.4.7


### PR DESCRIPTION
This fixes an issue with printf not printing doubles or floats
correctly, and probably other subtle issues.