### PR TITLE
Build and install cp from coreutils to replace our minimal cp

### DIFF
--- a/sysa/coreutils-5.0/mk/main.mk
+++ b/sysa/coreutils-5.0/mk/main.mk
@@ -78,8 +78,8 @@ COREUTILS = basename cat chmod cksum csplit cut echo expand factor false fmt fol
 
 BINARIES = $(addprefix $(SRC_DIR)/, $(COREUTILS))
 
-ALL=$(BINARIES) $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
-all: $(BINARIES) $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
+ALL=$(BINARIES) $(SRC_DIR)/cp $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
+all: $(BINARIES) $(SRC_DIR)/cp $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
 
 LIB_DIR = lib
 LIB_SRC = acl getdate posixtm posixver strftime getopt getopt1 hash hash-pjw addext argmatch backupfile basename canon-host closeout cycle-check diacrit dirname dup-safer error exclude exitfail filemode __fpending file-type fnmatch fopen-safer full-read full-write getline getstr gettime hard-locale human idcache isdir imaxtostr linebuffer localcharset long-options makepath mbswidth md5 memcasecmp memcoll modechange offtostr path-concat physmem quote quotearg readtokens rpmatch safe-read safe-write same save-cwd savedir settime sha stpcpy stripslash strtoimax strtoumax umaxtostr unicodeio userspec version-etc xgetcwd xgethostname xmalloc xmemcoll xnanosleep xreadlink xstrdup xstrtod xstrtol xstrtoul xstrtoimax xstrtoumax yesno strnlen getcwd sig2str mountlist regex canonicalize mkstemp memrchr euidaccess ftw dirfd obstack strverscmp strftime tsearch

--- a/sysa/coreutils-5.0/mk/pass2.mk
+++ b/sysa/coreutils-5.0/mk/pass2.mk
@@ -87,8 +87,8 @@ COREUTILS = basename cat chmod cksum comm csplit cut date dd echo expand expr fa
 
 BINARIES = $(addprefix $(SRC_DIR)/, $(COREUTILS))
 
-ALL=$(BINARIES) $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
-all: $(BINARIES) $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
+ALL=$(BINARIES) $(SRC_DIR)/cp $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
+all: $(BINARIES) $(SRC_DIR)/cp $(SRC_DIR)/ls $(SRC_DIR)/install $(SRC_DIR)/md5sum $(SRC_DIR)/mv $(SRC_DIR)/rm $(SRC_DIR)/sha1sum
 
 LIB_DIR = lib
 LIB_SRC = acl alloca getdate posixtm posixver strftime getopt getopt1 hash hash-pjw addext argmatch backupfile basename canon-host closeout cycle-check diacrit dirname dup-safer error exclude exitfail filemode __fpending file-type fnmatch fopen-safer full-read full-write getline getstr gettime hard-locale human idcache isdir imaxtostr linebuffer localcharset long-options makepath mbswidth md5 memcasecmp memcoll modechange offtostr path-concat physmem quote quotearg readtokens rpmatch safe-read safe-write same save-cwd savedir settime sha stpcpy stripslash strtoimax strtoumax umaxtostr unicodeio userspec version-etc xgetcwd xgethostname xmalloc xmemcoll xnanosleep xreadlink xstrdup xstrtod xstrtol xstrtoul xstrtoimax xstrtoumax yesno strnlen getcwd sig2str mountlist regex canonicalize mkstemp memrchr euidaccess ftw obstack strverscmp strftime tsearch

--- a/sysa/tcc-0.9.27/tcc-musl.sh
+++ b/sysa/tcc-0.9.27/tcc-musl.sh
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 src_unpack() {
-    # Our cp does not support recursive copying
-    tar -c -C ../src/ -f tcc-0.9.27.tar tcc-0.9.27/
-    tar -xf tcc-0.9.27.tar
+    cp -r ../src/tcc-0.9.27 .
 }
 
 src_prepare() {


### PR DESCRIPTION
Also update tcc-musl.sh to take advantage that cp can now copy
recursively