### PR TITLE
Perl

### DIFF
--- a/sysa/bash-2.05b/mk/builtins.mk
+++ b/sysa/bash-2.05b/mk/builtins.mk
@@ -24,4 +24,4 @@ BUILTINS_OBJS = $(BUILTINS_DEF_OBJS) $(BUILTINS_STATIC_OBJS)
 	$(CC) -c $(CFLAGS) -o $@ $*.c
 
 libbuiltins.a: $(BUILTINS_OBJS) builtins.o
-	$(AR) cr $@ $(BUILTINS_OBJS) builtins.o
+	$(AR) cr $@ $^

--- a/sysa/perl-5.6.2/checksums
+++ b/sysa/perl-5.6.2/checksums
@@ -1,1 +1,1 @@
-108b81c3a43b6c2aeac9fb575225e2dd76b199ef17cec458f1f6a3a95bf20ecf  /after/bin/perl
+98cbb417ac4dc35a91682d91cc34c598bcaf0a37315db71bc65c51184e876e22  /after/bin/perl

--- a/sysa/perl-5.6.2/files/config.h
+++ b/sysa/perl-5.6.2/files/config.h
@@ -19,6 +19,8 @@
 
 #define HAS_SYSCALL
 #define HAS_TIMES
+#define HAS_FLOCK
+#define HAS_TRUNCATE
 
 #define HAS_VPRINTF
 #define Gid_t gid_t
@@ -69,6 +71,7 @@
 #define ARCHLIB "/after/lib/perl5/"
 
 #define CAT2(a,b) a##b
+#define STRINGIFY(a) "a"
 #define Gconvert(x,n,t,b) gcvt((x),(n),(b))
 
 #define Time_t time_t
@@ -96,6 +99,7 @@
 #define NVSIZE 8 /* sizeof(double) */
 #define UVSIZE 4 /* sizeof(long) on i386 */
 #define IVSIZE 4
+#define PTRSIZE 4
 
 #define IVTYPE long
 #define UVTYPE unsigned long

--- a/sysa/perl-5.6.2/files/config.sh
+++ b/sysa/perl-5.6.2/files/config.sh
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2021 Andrius Štikonas <andrius@stikonas.eu>
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+ar='tcc -ar'
+cc='tcc'
+ldlibpthname='LD_LIBRARY_PATH'
+libpth='/after/lib'
+path_sep=':'
+
+CONFIGDOTSH=true

--- a/sysa/perl-5.6.2/mk/main.mk
+++ b/sysa/perl-5.6.2/mk/main.mk
@@ -6,21 +6,130 @@ VERSION=5.6.2
 PRIVLIB_EXP=$(PREFIX)/lib/perl5/$(VERSION)
 
 CC      = tcc
+AR      = tcc -ar
 CFLAGS  = -DPRIVLIB_EXP=\"$(PRIVLIB_EXP)\" \
-          -DPERL_EXTERNAL_GLOB \
-          -DPERL_CORE=1
+          -DPERL_CORE=1 \
+          -I. \
+          -DVERSION=\"$(VERSION)\"
+
+MINICFLAGS = -DPERL_EXTERNAL_GLOB
 
 .PHONY: all
 
-MINIPERL_SRC = av deb doio doop dump globals gv hv mg miniperlmain op perl perlapi perlio perly pp pp_ctl pp_hot pp_sys regcomp regexec run scope sv taint toke universal utf8 util xsutils
-MINIPERL_OBJ = $(addsuffix .o, $(MINIPERL_SRC))
+LIBPERL_SRC = av deb doio doop dump globals gv hv mg op perl perlapi perlio perly pp pp_ctl pp_hot pp_sys regcomp regexec run scope sv taint toke universal utf8 util xsutils
+LIBPERL_OBJ = $(addsuffix .o, $(LIBPERL_SRC))
 
-all: miniperl
+# POSIX is dealt with separately, Errno has no .a files either
+EXTENSIONS = ByteLoader Data/Dumper Fcntl File/Glob IO
+EXTENSIONS_A := $(foreach f,$(EXTENSIONS), lib/auto/$f/$(notdir $f).a)
 
-miniperl: $(MINIPERL_OBJ)
-	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
+EXTRA_EXTENSIONS = POSIX
+EXTRA_EXTENSIONS_A = $(foreach f,$(EXTRA_EXTENSIONS), lib/auto/$f/$(notdir $f).a)
+
+all: perl
+
+op-mini.c: op.c
+	cp op.c op-mini.c
+
+libperl.a: $(LIBPERL_OBJ)
+	$(AR) cr $@ $^
+
+miniperl: miniperlmain.o op-mini.o libperl.a
+	$(CC) $(CFLAGS) $(MINICFLAGS) $^ $(LDFLAGS) -o $@
+
+lib/re.pm:
+	cp ext/re/re.pm lib/re.pm
+
+config.sh:
+	echo "CONFIGDOTSH=true" > $@
+
+lib/Config.pm: config.sh miniperl configpm lib/re.pm
+	./miniperl configpm $@
+
+autosplit.pl: lib/Config.pm
+	echo 'use AutoSplit; autosplit_lib_modules(@ARGV)' > $@
+
+prepare_library: autosplit.pl miniperl lib/re.pm
+	./miniperl -Ilib $< lib/*.pm lib/*/*.pm
+
+lib/ExtUtils/Miniperl.pm: miniperl
+	./miniperl minimod.pl > $@
+
+writemain: writemain.SH config.sh
+	spitshell=cat eunicefix=true ./$<
+
+perlmain.c: writemain
+	./writemain $(EXTENSIONS_A) $(EXTRA_EXTENSIONS_A) > $@
+
+ext/DynaLoader/DynaLoader.pm: miniperl lib/Config.pm
+	./miniperl -Ilib ext/DynaLoader/DynaLoader_pm.PL DynaLoader.pm
+	mv DynaLoader.pm $@
+	$(MAKE) prepare_library
+
+ext/DynaLoader/XSLoader.pm: miniperl lib/Config.pm
+	./miniperl -Ilib ext/DynaLoader/XSLoader_pm.PL XSLoader.pm
+	mv XSLoader.pm $@
+
+ext/DynaLoader/DynaLoader.xs: ext/DynaLoader/DynaLoader.pm ext/DynaLoader/XSLoader.pm
+	cp ext/DynaLoader/dl_dlopen.xs $@
+
+ext/DynaLoader/DynaLoader.c: ext/DynaLoader/DynaLoader.xs miniperl
+	cd $(dir $@); \
+	$(CURDIR)/miniperl -I$(CURDIR)/lib $(CURDIR)/lib/ExtUtils/xsubpp -noprototypes -typemap $(CURDIR)/lib/ExtUtils/typemap $(notdir $<) > $(notdir $@)
+
+lib/auto/DynaLoader/DynaLoader.a: ext/DynaLoader/DynaLoader.o
+	mkdir -p lib/auto/DynaLoader
+	$(AR) cr $@ $^
+
+ext/POSIX/POSIX.c: ext/POSIX/POSIX.xs miniperl
+	cd $(dir $@); \
+	$(CURDIR)/miniperl -I$(CURDIR)/lib $(CURDIR)/lib/ExtUtils/xsubpp -noprototypes -typemap $(CURDIR)/lib/ExtUtils/typemap $(notdir $<) > $(notdir $@)
+
+lib/auto/POSIX/POSIX.a: ext/POSIX/POSIX.o
+	mkdir -p lib/auto/POSIX
+	$(AR) cr $@ $^
+	mkdir -p ext/POSIX/blib/lib
+	cp ext/POSIX/POSIX.pod ext/POSIX/POSIX.pm ext/POSIX/blib/lib
+	cd ext/POSIX/blib; \
+	../../../miniperl -I../../../lib $(CURDIR)/autosplit.pl lib/*.pm
+	cp ext/POSIX/blib/lib/auto/POSIX/* lib/auto/POSIX/
+
+define build_rule
+    lib/auto/$1/$(notdir $1).a: ext/$1/$(notdir $1).o $(patsubst %.c,%.o,$(wildcard ext/$1/*.c))
+	mkdir -p lib/auto/$1
+	$(AR) cr lib/auto/$1/$(notdir $1).a ext/$1/$(notdir $1).o $(patsubst %.c,%.o,$(wildcard ext/$1/*.c))
+	cp ext/$1/$(notdir $1).pm lib/auto/$1/
+
+    ext/$1/$(notdir $1).c: ext/$1/$(notdir $1).xs miniperl lib/Config.pm
+	cd ext/$1; \
+	$(CURDIR)/miniperl -I$(CURDIR)/lib $(CURDIR)/lib/ExtUtils/xsubpp -noprototypes -typemap $(CURDIR)/lib/ExtUtils/typemap $(notdir $1).xs > $(notdir $1).c
+endef
+$(foreach f,$(EXTENSIONS),$(eval $(call build_rule,$f)))
+
+lib/Errno.pm: miniperl
+	cd ext/Errno; \
+	../../miniperl -I../../lib Errno_pm.PL
+	mv ext/Errno/Errno.pm $@
+
+perl: perlmain.o lib/auto/DynaLoader/DynaLoader.a $(EXTENSIONS_A) lib/auto/POSIX/POSIX.a libperl.a lib/re.pm lib/Errno.pm
+	$(CC) $(CFLAGS) perlmain.o lib/auto/DynaLoader/DynaLoader.a $(EXTENSIONS_A) lib/auto/POSIX/POSIX.a libperl.a -o $@
 
 install: all
-	install miniperl $(PREFIX)/bin/perl
+	install perl $(PREFIX)/bin/perl
 	mkdir -p "$(PRIVLIB_EXP)"
 	cp -r lib/* "$(PRIVLIB_EXP)"
+
+	install -m 644 ext/DynaLoader/XSLoader.pm "$(PRIVLIB_EXP)"
+	install -m 644 ext/DynaLoader/DynaLoader.pm "$(PRIVLIB_EXP)"
+
+	install -m 644 ext/ByteLoader/ByteLoader.pm "$(PRIVLIB_EXP)"
+	mkdir "$(PRIVLIB_EXP)/Data/"
+	install -m 644 ext/Data/Dumper/Dumper.pm "$(PRIVLIB_EXP)/Data/"
+	install -m 644 ext/Fcntl/Fcntl.pm "$(PRIVLIB_EXP)"
+	install -m 644 ext/File/Glob/Glob.pm "$(PRIVLIB_EXP)/File/"
+	install -m 644 ext/IO/IO.pm "$(PRIVLIB_EXP)"
+	mkdir "$(PRIVLIB_EXP)/IO/"
+	cp ext/IO/lib/IO/*.pm "$(PRIVLIB_EXP)/IO/"
+	install -m 644 ext/POSIX/POSIX.pm "$(PRIVLIB_EXP)/"
+	install -m 644 ext/POSIX/POSIX.pod "$(PRIVLIB_EXP)/"
+	cp lib/auto/POSIX/* "$(PRIVLIB_EXP)/auto/POSIX/"

--- a/sysa/perl-5.6.2/perl-5.6.2.sh
+++ b/sysa/perl-5.6.2/perl-5.6.2.sh
@@ -23,6 +23,14 @@ src_prepare() {
     perl bytecode.pl
     rm warnings.h lib/warnings.pm
     perl warnings.pl
+
+    # Workaround for some linking problems, remove if possible
+    sed -i 's/perl_call_method/Perl_call_method/' ext/Data/Dumper/Dumper.xs
+    sed -i 's/perl_call_sv/Perl_call_sv/' ext/Data/Dumper/Dumper.xs
+    sed -i 's/sv_setptrobj/Perl_sv_setref_iv/' ext/POSIX/POSIX.xs
+
+    # We are using non-standard locations
+    sed -i 's#/usr/include/errno.h#/after/include/musl/bits/errno.h#' ext/Errno/Errno_pm.PL
 }
 
 src_install() {


### PR DESCRIPTION
Build perl with some statically linked modules.

This can run newer automakes but for some reason newer autoconfs don't work. Although, I'm not yet sure if perl is to blame, something goes wrong when building frozen m4 files.