### PR TITLE
Remove dev console

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,12 +45,12 @@ run_task:
   deps_script:
     - apt-get -y update
     - apt-get -y dist-upgrade
-    - apt-get -y install sudo git cpio linux-image-4.19.0-13-amd64 expect wget
+    - apt-get -y install sudo git cpio linux-image-4.19.0-16-amd64 expect wget
     - apt-get -y clean
   submodule_script:
     - git submodule update --init --recursive
   kernel_script:
-    - cp /boot/vmlinuz-4.19.0-13-amd64 ./kernel
+    - cp /boot/vmlinuz-4.19.0-16-amd64 ./kernel
   run_script:
     - ./.cirrus.expect | tee -a /tmp/run.log
     - grep -q 'Bootstrapping completed.' /tmp/run.log

--- a/sysa/musl-1.1.24/binutils-rebuild.sh
+++ b/sysa/musl-1.1.24/binutils-rebuild.sh
@@ -18,7 +18,9 @@ src_configure() {
       --includedir=/after/include/
 
     # configure script creates this file
-    test -f /dev/null && rm /dev/null
+    if test -f /dev/null; then
+        rm /dev/null
+    fi
 }
 
 src_compile() {

--- a/sysa/musl-1.1.24/musl-1.1.24.sh
+++ b/sysa/musl-1.1.24/musl-1.1.24.sh
@@ -21,7 +21,9 @@ src_configure() {
       --includedir=/after/include/musl
 
     # configure script creates this file
-    test -f /dev/null && rm /dev/null
+    if test -f /dev/null; then
+        rm /dev/null
+    fi
 }
 
 src_compile() {

--- a/sysa/musl-1.2.2/musl-1.2.2.sh
+++ b/sysa/musl-1.2.2/musl-1.2.2.sh
@@ -11,7 +11,10 @@ src_configure() {
         --includedir=/after/include/
 
     # configure script creates this file
-    test -f /dev/null && rm /dev/null && mknod -m 666 /dev/null c 1 3
+    if test -f /dev/null; then
+        rm /dev/null
+        mknod -m 666 /dev/null c 1 3
+    fi
 }
 
 src_compile() {

--- a/sysa/run.sh
+++ b/sysa/run.sh
@@ -12,7 +12,6 @@ set -e
 
 populate_device_nodes() {
     # http://www.linuxfromscratch.org/lfs/view/6.1/chapter06/devices.html
-    test -c /dev/console || mknod -m 622 /dev/console c 5 1
     test -c /dev/null || mknod -m 666 /dev/null c 1 3
     test -c /dev/zero || mknod -m 666 /dev/zero c 1 5
     test -c /dev/ptmx || mknod -m 666 /dev/ptmx c 5 2


### PR DESCRIPTION
This allows musl to build if /dev is already populated in the chroot.
Remove `/dev/console` as it isn't used and isn't useful, we use stdio as attached to init to communicate with the user in a portable (chroot / baremetal) way.