### PR TITLE
Fix perl warning due to uninitialized variables

### DIFF
--- a/sysa/perl-5.6.2/files/config.sh
+++ b/sysa/perl-5.6.2/files/config.sh
@@ -7,5 +7,7 @@ cc='tcc'
 ldlibpthname='LD_LIBRARY_PATH'
 libpth='/after/lib'
 path_sep=':'
+archname=''
+osvers=''
 
 CONFIGDOTSH=true


### PR DESCRIPTION
Use of uninitialized value in concatenation (.) or string at
/after/lib/perl5/5.6.2/Errno.pm line 11.