### PR TITLE
Recreate autoconf.in file from autoconf.as

### DIFF
--- a/sysa/autoconf-2.54/stage1.sh
+++ b/sysa/autoconf-2.54/stage1.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 src_prepare() {
+    rm bin/autoconf.in
     rm Makefile.in */Makefile.in */*/Makefile.in aclocal.m4 configure
     aclocal-1.7
     sed -i 's/2.54/2.53/' aclocal.m4
@@ -24,6 +25,9 @@ src_configure() {
 }
 
 src_compile() {
+    # Workaround for racy make dependencies
+    make -C bin autom4te
+    make -C lib
     make MAKEINFO=true
 }
 

--- a/sysa/autoconf-2.54/stage2.sh
+++ b/sysa/autoconf-2.54/stage2.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 src_prepare() {
+    rm bin/autoconf.in
     rm Makefile.in */Makefile.in */*/Makefile.in aclocal.m4 configure
 
     autoreconf-2.54
@@ -18,7 +19,10 @@ src_configure() {
 }
 
 src_compile() {
-    make MAKEINFO=true DESTDIR="${DESTDIR}"
+    # Workaround for racy make dependencies
+    make -C bin autom4te
+    make -C lib
+    make MAKEINFO=true
 }
 
 src_install() {

--- a/sysa/autoconf-2.55/autoconf-2.55.sh
+++ b/sysa/autoconf-2.55/autoconf-2.55.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 src_prepare() {
+    rm bin/autoconf.in
     rm Makefile.in */Makefile.in */*/Makefile.in aclocal.m4 configure
 
     autoreconf-2.54
@@ -18,6 +19,10 @@ src_configure() {
 }
 
 src_compile() {
+    # Workaround for racy make dependencies
+    make -C bin autom4te
+    make -C lib
+
     make MAKEINFO=true
 }
 

--- a/sysa/autoconf-2.57/autoconf-2.57.sh
+++ b/sysa/autoconf-2.57/autoconf-2.57.sh
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 src_prepare() {
+    rm bin/autoconf.in
+
     autoreconf-2.55 -f
 
     # Install autoconf data files into versioned directory
@@ -16,6 +18,9 @@ src_configure() {
 }
 
 src_compile() {
+    # Workaround for racy make dependencies
+    make -C bin autom4te
+    make -C lib
     make MAKEINFO=true
 }
 

--- a/sysa/autoconf-2.59/autoconf-2.59.sh
+++ b/sysa/autoconf-2.59/autoconf-2.59.sh
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 src_prepare() {
+    rm bin/autoconf.in
+
     autoreconf-2.57 -f
 
     # Install autoconf data files into versioned directory
@@ -16,6 +18,9 @@ src_configure() {
 }
 
 src_compile() {
+    # Workaround for racy make dependencies
+    make -C bin autom4te
+    make -C lib
     make MAKEINFO=true
 }
 


### PR DESCRIPTION
Fixes: #92

There is a Makefile target for that but at least in autoconf 2.57 is seems to be a bit racy. So make sure to recreate it.
And since autoconf.in is pre-generated, we want to recreate it anyway.

Note that in autoconf 2.53 autoconf.in is handwritten. And autoconf 2.61 and later don't ship pregenerated autoconf.in and always builds it (hopefully they fixed race in later autoconfs).