### PR TITLE
Fix intermittent error when bootstrapping automake-1.13.4

### DIFF
--- a/sysa/automake-1.13.4/patches/bootstrap.patch
+++ b/sysa/automake-1.13.4/patches/bootstrap.patch
@@ -1,0 +1,17 @@
+SPDX-FileCopyrightText: 2021 Andrius Štikonas <andrius@stikonas.eu>
+
+SPDX-License-Identifier: GPL-2.0-or-later
+
+Fixes dependency of bootstrapping script
+
+--- gen-testsuite-part  2017-06-16 21:46:16.000000000 +0100
++++ gen-testsuite-part  2021-04-01 00:02:46.801098617 +0100
+@@ -64,8 +64,6 @@
+   $func->($fh);
+   close $fh
+     or die "$me: closing '$tmpfile': $!\n";
+-  chmod ($perms & ~umask, $tmpfile)
+-    or die "$me: cannot change perms for '$tmpfile': $!\n";
+   rename ($tmpfile, $outfile)
+     or die "$me: renaming '$tmpfile' -> '$outfile: $!\n'";
+ }


### PR DESCRIPTION
Our perl does not seem to recognize umask keyword

Fixes: #93

(Patch is just copied from automake-1.15 directory).

Actually we should also rebuild generated file `t/testsuite-part.am`