### PR TITLE
Remove some unused pregen-files in coreutils 6.

### DIFF
--- a/sysa/coreutils-6.10/coreutils-6.10.sh
+++ b/sysa/coreutils-6.10/coreutils-6.10.sh
@@ -6,6 +6,9 @@ src_prepare() {
     default
     mv lib/fnmatch.in.h lib/fnmatch.h
 
+    # gperf pregenerated files
+    rm lib/iconv_open-hpux.h lib/iconv_open-aix.h lib/iconv_open-irix.h lib/iconv_open-osf.h
+
     # Rebuild bison pre-generated file
     rm lib/getdate.c
     cd lib


### PR DESCRIPTION
Remove some pregen files as a precaution (they were not used).