### PR TITLE
Preparations for rootless bootstrap of sysa

### DIFF
--- a/sysa/after.kaem
+++ b/sysa/after.kaem
@@ -23,7 +23,7 @@ NYACC_PKG=nyacc-1.00.2
 MES_PKG=mes
 MES_PREFIX=${sources}/${MES_PKG}/src/mes-m2-dad1744fa80f52b3b428803c06b09d39c285f500
 GUILE_LOAD_PATH=${MES_PREFIX}/mes/module:${MES_PREFIX}/module:${sources}/${MES_PKG}/src/${NYACC_PKG}/module
-mkdir ${prefix} ${bindir} ${libdir} ${incdir} ${tmpdir}
+mkdir -p ${prefix} ${bindir} ${libdir} ${incdir} ${tmpdir}
 cd ${prefix}
 
 # Remove remaining dependencies on /bin (stage0-posix directory)

--- a/sysa/bash-2.05b/bash-2.05b.kaem
+++ b/sysa/bash-2.05b/bash-2.05b.kaem
@@ -12,7 +12,7 @@ mkdir build
 cd build
 
 # Extract
-gunzip ../src/${pkg}.tar.gz
+gunzip -f ../src/${pkg}.tar.gz
 tar xf ../src/${pkg}.tar
 cd ${pkg}
 cp ../../mk/main.mk Makefile

--- a/sysa/bzip2-1.0.8/bzip2-1.0.8.kaem
+++ b/sysa/bzip2-1.0.8/bzip2-1.0.8.kaem
@@ -11,7 +11,7 @@ mkdir build
 cd build 
 
 # Extract
-gunzip ../src/${pkg}.tar.gz
+gunzip -f ../src/${pkg}.tar.gz
 tar xf ../src/${pkg}.tar
 cd ${pkg}
 

--- a/sysa/coreutils-5.0/coreutils-5.0.kaem
+++ b/sysa/coreutils-5.0/coreutils-5.0.kaem
@@ -12,7 +12,7 @@ mkdir build
 cd build
 
 # Extract
-bunzip2 ../src/${pkg}.tar.bz2
+bunzip2 -f ../src/${pkg}.tar.bz2
 tar xf ../src/${pkg}.tar
 cd ${pkg}
 cp ../../mk/main.mk Makefile

--- a/sysa/coreutils-5.0/coreutils-5.0.sh
+++ b/sysa/coreutils-5.0/coreutils-5.0.sh
@@ -4,6 +4,10 @@
 
 src_unpack() {
     src_dir="${base_dir}/src"
+
+    # Remove previous source diretory
+    rm -rf "${pkg}"
+
     tar -xf "${src_dir}/${pkg}.tar"
 }
 

--- a/sysa/findutils-4.2.33/findutils-4.2.33.sh
+++ b/sysa/findutils-4.2.33/findutils-4.2.33.sh
@@ -5,6 +5,8 @@
 src_prepare() {
     . ../../import-gnulib.sh
 
+    default_src_prepare
+
     autoreconf-2.61 -f
 
     # Pre-built texinfo files

--- a/sysa/findutils-4.2.33/patches/force-getcwd-fallback.patch
+++ b/sysa/findutils-4.2.33/patches/force-getcwd-fallback.patch
@@ -1,0 +1,18 @@
+SPDX-FileCopyrightText: 2022 Dor Askayo <dor.askayo@gmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Use the fallback implementations of getcwd to get the same /usr/bin/find
+checksum when building across FUSE and non-FUSE filesystems.
+
+--- gnulib/m4/getcwd-path-max.m4	2022-01-08 13:16:54.412709192 +0200
++++ gnulib/m4/getcwd-path-max.m4	2022-01-16 11:38:02.658606802 +0200
+@@ -81,7 +81,7 @@
+   char *cwd = getcwd (buf, PATH_MAX);
+   size_t initial_cwd_len;
+   size_t cwd_len;
+-  int fail = 0;
++  int fail = 1;
+   size_t n_chdirs = 0;
+ 
+   if (cwd == NULL)

--- a/sysa/heirloom-devtools-070527/heirloom-devtools-070527.kaem
+++ b/sysa/heirloom-devtools-070527/heirloom-devtools-070527.kaem
@@ -13,7 +13,7 @@ cd build
 lexdir=/lex
 
 # Extract
-bunzip2 ../src/${pkg}.tar.bz2
+bunzip2 -f ../src/${pkg}.tar.bz2
 tar xf ../src/${pkg}.tar ${pkg}/yacc ${pkg}/lex
 cd ${pkg}
 

--- a/sysa/help2man-1.36.4/help2man-1.36.4.sh
+++ b/sysa/help2man-1.36.4/help2man-1.36.4.sh
@@ -17,8 +17,9 @@ src_compile() {
     make MAKEINFO=true
 
     # fix a broken shebang
+    chmod +w help2man
     tail -n +6 help2man > help2man.tmp
-    echo "#!/${PREFIX}/bin/perl" > help2man
+    echo "#!${PREFIX}/bin/perl" > help2man
     cat help2man.tmp >> help2man
     rm help2man.tmp
 }

--- a/sysa/make-3.80/make-3.80.kaem
+++ b/sysa/make-3.80/make-3.80.kaem
@@ -10,7 +10,7 @@ mkdir build
 cd build 
 
 # Extract
-gunzip ../src/${pkg}.tar.gz
+gunzip -f ../src/${pkg}.tar.gz
 tar xf ../src/${pkg}.tar
 cd ${pkg}
 

--- a/sysa/patch-2.5.9/patch-2.5.9.kaem
+++ b/sysa/patch-2.5.9/patch-2.5.9.kaem
@@ -10,7 +10,7 @@ mkdir build
 cd build
 
 # Extract
-gunzip ../src/${pkg}.tar.gz
+gunzip -f ../src/${pkg}.tar.gz
 tar xf ../src/${pkg}.tar
 cd ${pkg}
 

--- a/sysa/perl-5.000/perl-5.000.sh
+++ b/sysa/perl-5.000/perl-5.000.sh
@@ -12,22 +12,22 @@ src_prepare() {
     default
 
     # Remove and regenerate bison files
-    rm perly.c perly.h
+    rm -f perly.c perly.h
     bison -d perly.y
     mv perly.tab.c perly.c
     mv perly.tab.h perly.h
 
     # Regenerate embed.h
-    rm embed.h
+    rm -f embed.h
     ./embed_h.SH
 
     # Regenerate keywords.h
-    rm keywords.h
+    rm -f keywords.h
     chmod +x keywords.sh
     ./keywords.sh
 
     # Regenerate opcode.h
-    rm opcode.h
+    rm -f opcode.h
     chmod +x opcode.sh
     ./opcode.sh
 }

--- a/sysa/perl-5.003/perl-5.003.sh
+++ b/sysa/perl-5.003/perl-5.003.sh
@@ -12,14 +12,14 @@ src_prepare() {
     default
 
     # Regenerate bison files
-    rm perly.c perly.h
+    rm -f perly.c perly.h
     bison -d perly.y
     mv perly.tab.c perly.c
     mv perly.tab.h perly.h
 
     # Regenerate other prebuilt header files
     for file in embed keywords opcode; do
-        rm ${file}.h
+        rm -f ${file}.h
         perl ${file}.pl
     done
 }

--- a/sysa/perl-5.6.2/perl-5.6.2.sh
+++ b/sysa/perl-5.6.2/perl-5.6.2.sh
@@ -7,21 +7,21 @@ src_prepare() {
 
     # Regenerate bison files
     sed -i '/yydestruct/d' perly.y
-    rm perly.c perly.h
+    rm -f perly.c perly.h
     bison -d perly.y
     mv perly.tab.c perly.c
     mv perly.tab.h perly.h
 
     # Regenerate other prebuilt header files
     for file in embed keywords opcode; do
-        rm ${file}.h
+        rm -f ${file}.h
         perl ${file}.pl
     done
-    rm regnodes.h
+    rm -f regnodes.h
     perl regcomp.pl
-    rm ext/ByteLoader/byterun.h ext/ByteLoader/byterun.c
+    rm -f ext/ByteLoader/byterun.h ext/ByteLoader/byterun.c
     perl bytecode.pl
-    rm warnings.h lib/warnings.pm
+    rm -f warnings.h lib/warnings.pm
     perl warnings.pl
 
     # Workaround for some linking problems, remove if possible

--- a/sysa/perl5.004_05/perl5.004_05.sh
+++ b/sysa/perl5.004_05/perl5.004_05.sh
@@ -6,14 +6,14 @@ src_prepare() {
     default
 
     # Regenerate bison files
-    rm perly.c perly.h
+    rm -f perly.c perly.h
     bison -d perly.y
     mv perly.tab.c perly.c
     mv perly.tab.h perly.h
 
     # Regenerate other prebuilt header files
     for file in embed keywords opcode; do
-        rm ${file}.h
+        rm -f ${file}.h
         perl ${file}.pl
     done
 }

--- a/sysa/perl5.005_03/perl5.005_03.sh
+++ b/sysa/perl5.005_03/perl5.005_03.sh
@@ -6,19 +6,19 @@ src_prepare() {
     default
 
     # Regenerate bison files
-    rm perly.c perly.h
+    rm -f perly.c perly.h
     bison -d perly.y
     mv perly.tab.c perly.c
     mv perly.tab.h perly.h
 
     # Regenerate other prebuilt header files
     for file in embed keywords opcode; do
-        rm ${file}.h
+        rm -f ${file}.h
         perl ${file}.pl
     done
-    rm regnodes.h
+    rm -f regnodes.h
     perl regcomp.pl
-    rm byterun.h byterun.c
+    rm -f fbyterun.h byterun.c
     perl bytecode.pl
 }
 

--- a/sysa/sed-4.0.9/sed-4.0.9.kaem
+++ b/sysa/sed-4.0.9/sed-4.0.9.kaem
@@ -12,7 +12,7 @@ mkdir build
 cd build
 
 # Extract
-gunzip ../src/${pkg}.tar.gz
+gunzip -f ../src/${pkg}.tar.gz
 tar xf ../src/${pkg}.tar
 cd ${pkg}
 

--- a/sysa/tar-1.12/tar-1.12.kaem
+++ b/sysa/tar-1.12/tar-1.12.kaem
@@ -12,7 +12,7 @@ mkdir build
 cd build
 
 # Extract
-gunzip ../src/${pkg}.tar.gz
+gunzip -f ../src/${pkg}.tar.gz
 untar ../src/${pkg}.tar
 
 cd ${pkg}

--- a/sysa/tcc-0.9.27/tcc-0.9.27.kaem
+++ b/sysa/tcc-0.9.27/tcc-0.9.27.kaem
@@ -11,7 +11,7 @@ mkdir build
 cd build
 
 # Extract
-bunzip2 ../src/${pkg}.tar.bz2
+bunzip2 -f ../src/${pkg}.tar.bz2
 tar xf ../src/${pkg}.tar
 cd ${pkg}
 

--- a/sysc/perl-5.10.1/perl-5.10.1.sh
+++ b/sysc/perl-5.10.1/perl-5.10.1.sh
@@ -12,14 +12,14 @@ src_prepare() {
     # is not dependent on perly.y any more.
     perl regen_perly.pl -b bison-2.3
     # Remove the source file so make works.
-    rm perly.y
+    rm -f perly.y
 
     # Regenerate other prebuilt header files
     # Taken from headers of regen scripts
-    rm lib/warnings.pm warnings.h regnodes.h reentr.h reentr.c overload.h \
-        overload.c lib/overload/numbers.pm opcode.h opnames.h pp_proto.h \
-        pp.sym keywords.h embed.h embedvar.h global.sym perlapi.c perlapi.h \
-        proto.h
+    rm -f lib/warnings.pm warnings.h regnodes.h reentr.h reentr.c overload.h \
+          overload.c lib/overload/numbers.pm opcode.h opnames.h pp_proto.h \
+          pp.sym keywords.h embed.h embedvar.h global.sym perlapi.c perlapi.h \
+          proto.h
     perl regen.pl
 
     mkdir -p ext/File ext/Digest ext/Data

--- a/sysc/perl-5.32.1/perl-5.32.1.sh
+++ b/sysc/perl-5.32.1/perl-5.32.1.sh
@@ -14,15 +14,15 @@ src_prepare() {
 
     # Regenerate other prebuilt header files
     # Taken from headers of regen scripts
-    rm embed.h embedvar.h perlapi.c perlapi.h proto.h mg_names.inc mg_raw.h \
-        mg_vtable.h opcode.h opnames.h pp_proto.h \
-        lib/B/Op_private.pm overload.h overload.inc lib/overload/numbers.pm \
-        reentr.h reentr.c regnodes.h lib/warnings.pm \
-        warnings.h lib/feature.pm feature.h
+    rm -f embed.h embedvar.h perlapi.c perlapi.h proto.h mg_names.inc mg_raw.h \
+          mg_vtable.h opcode.h opnames.h pp_proto.h \
+          lib/B/Op_private.pm overload.h overload.inc lib/overload/numbers.pm \
+          reentr.h reentr.c regnodes.h lib/warnings.pm \
+          warnings.h lib/feature.pm feature.h
     perl regen.pl
 
     # Regenerate configure + config_h.SH
-    rm Configure config_h.SH
+    rm -f Configure config_h.SH
     ln -s ../perl-5f2dc80/regen-configure/.package .
     ln -s ../perl-5f2dc80/regen-configure/U .
     metaconfig -m

--- a/sysc/run.sh
+++ b/sysc/run.sh
@@ -10,6 +10,8 @@ set -e
 
 # shellcheck source=sysglobal/helpers.sh
 . helpers.sh
+# shellcheck source=/dev/null
+. bootstrap.cfg
 
 export PATH=/usr/bin:/usr/sbin
 export PREFIX=/usr

--- a/sysglobal/helpers.sh
+++ b/sysglobal/helpers.sh
@@ -172,9 +172,12 @@ populate_device_nodes() {
     mkdir -p "${1}/dev"
     test -c "${1}/dev/null" || mknod -m 666 "${1}/dev/null" c 1 3
     test -c "${1}/dev/zero" || mknod -m 666 "${1}/dev/zero" c 1 5
-    test -c "${1}/dev/ptmx" || mknod -m 666 "${1}/dev/ptmx" c 5 2
-    test -c "${1}/dev/tty" || mknod -m 666 "${1}/dev/tty" c 5 0
     test -c "${1}/dev/random" || mknod -m 444 "${1}/dev/random" c 1 8
     test -c "${1}/dev/urandom" || mknod -m 444 "${1}/dev/urandom" c 1 9
-    test -c "${1}/dev/console" || mknod -m 666 "${1}/dev/console" c 5 1
+
+    if [ "${CHROOT}" = False ]; then
+        test -c "${1}/dev/ptmx" || mknod -m 666 "${1}/dev/ptmx" c 5 2
+        test -c "${1}/dev/tty" || mknod -m 666 "${1}/dev/tty" c 5 0
+        test -c "${1}/dev/console" || mknod -m 666 "${1}/dev/console" c 5 1
+    fi
 }


### PR DESCRIPTION
These changes are required when the user performing the bootstrap doesn't have root permissions. They were tested with my WIP rootless-bootstrap mode (https://github.com/doraskayo/live-bootstrap/commits/bwrap-bootstrap) and with my local BuildStream-based bootstrap.

More information is available in each commit message.