### PR TITLE
sysgeneral: instruct tar to unlink files before creating them

### DIFF
--- a/sysa/automake-1.4-p6/automake-1.4-p6.sh
+++ b/sysa/automake-1.4-p6/automake-1.4-p6.sh
@@ -22,4 +22,6 @@ src_compile() {
 
 src_install() {
     make install MAKEINFO=true DESTDIR="${DESTDIR}"
+    rm "${DESTDIR}${PREFIX}/bin/automake"
+    rm "${DESTDIR}${PREFIX}/bin/aclocal"
 }

--- a/sysa/automake-1.6.3/stage3.sh
+++ b/sysa/automake-1.6.3/stage3.sh
@@ -25,4 +25,6 @@ src_install() {
     rm -rf "${PREFIX}"/share/aclocal-1.6
 
     make install MAKEINFO=true DESTDIR="${DESTDIR}"
+    rm "${DESTDIR}${PREFIX}/bin/automake"
+    rm "${DESTDIR}${PREFIX}/bin/aclocal"
 }


### PR DESCRIPTION
Discovered when building using unshare and no tmpfs, resulting in `/usr/bin/automake-1.4`, `/usr/bin/automake-1.6` and `/usr/bin/automake` all being hardlinked together.