### PR TITLE
Don't export variables from bootstrap.cfg

### DIFF
--- a/sysa/run.sh
+++ b/sysa/run.sh
@@ -72,7 +72,7 @@ if [ -z "${CHROOT}" ]; then
     ask_chroot
     echo
 
-    echo "export CHROOT=${CHROOT}" >> "${SOURCES}/bootstrap.cfg"
+    echo "CHROOT=${CHROOT}" >> "${SOURCES}/bootstrap.cfg"
 fi
 
 ask_timestamps() {
@@ -94,12 +94,12 @@ if [ -z "${FORCE_TIMESTAMPS}" ]; then
     ask_timestamps
     echo
 
-    echo "export FORCE_TIMESTAMPS=${FORCE_TIMESTAMPS}" >> "${SOURCES}/bootstrap.cfg"
+    echo "FORCE_TIMESTAMPS=${FORCE_TIMESTAMPS}" >> "${SOURCES}/bootstrap.cfg"
 fi
 
 echo "Thank you! All done."
 
-echo "export ARCH=${ARCH}" >> "${SOURCES}/bootstrap.cfg"
+echo "ARCH=${ARCH}" >> "${SOURCES}/bootstrap.cfg"
 
 mkdir -p "${DESTDIR}" "${REPO}" /dev
 

--- a/sysa/run.sh
+++ b/sysa/run.sh
@@ -71,6 +71,8 @@ if [ -z "${CHROOT}" ]; then
     echo "or not. Is it? (yes/no answer)"
     ask_chroot
     echo
+
+    echo "export CHROOT=${CHROOT}" >> "${SOURCES}/bootstrap.cfg"
 fi
 
 ask_timestamps() {
@@ -91,15 +93,13 @@ if [ -z "${FORCE_TIMESTAMPS}" ]; then
     echo "fully reproducible disk image. (yes/no answer)"
     ask_timestamps
     echo
+
+    echo "export FORCE_TIMESTAMPS=${FORCE_TIMESTAMPS}" >> "${SOURCES}/bootstrap.cfg"
 fi
 
 echo "Thank you! All done."
 
-# Write to bootstrap.cfg
-rm "${SOURCES}/bootstrap.cfg"
-for var in CHROOT FORCE_TIMESTAMPS DISK ARCH UPDATE_CHECKSUMS; do
-    echo "export ${var}=${!var}" >> "${SOURCES}/bootstrap.cfg"
-done
+echo "export ARCH=${ARCH}" >> "${SOURCES}/bootstrap.cfg"
 
 mkdir -p "${DESTDIR}" "${REPO}" /dev
 

--- a/sysb/run.sh
+++ b/sysb/run.sh
@@ -54,7 +54,7 @@ if [ -z "${DISK}" ] || ! [ -e "/dev/${DISK}" ]; then
     echo "You did not provide a valid disk in the configuration file."
     ask_disk
 
-    echo "export DISK=${DISK}" >> /usr/src/bootstrap.cfg
+    echo "DISK=${DISK}" >> /usr/src/bootstrap.cfg
 fi
 
 PREFIX=/usr

--- a/sysb/run.sh
+++ b/sysb/run.sh
@@ -53,13 +53,13 @@ ask_disk() {
 if [ -z "${DISK}" ] || ! [ -e "/dev/${DISK}" ]; then
     echo "You did not provide a valid disk in the configuration file."
     ask_disk
+
+    echo "export DISK=${DISK}" >> /usr/src/bootstrap.cfg
 fi
 
 PREFIX=/usr
 SOURCES="${PREFIX}/src"
 SYSC=/sysc
-
-echo "export DISK=${DISK}" >> /usr/src/bootstrap.cfg
 
 # Otherwise, add stuff from sysa to sysb
 echo "Mounting sysc"


### PR DESCRIPTION
From the main commit message:
<pre>
These variables should only affect live-bootstrap's scripts, yet they
currently "pollute" the build environment of most packages during the
bootstrap unnecessarily.
    
This change also makes bootstrap.cfg keep the same format between the
different bootstrap stages, which simplifies the input to each step.
</pre>