### PR TITLE
Fix file permissions for run2.kaem

### DIFF
--- a/sysa/after.kaem
+++ b/sysa/after.kaem
@@ -59,6 +59,6 @@ PATH=${bindir}
 cd ${sysa}
 
 catm run2.kaem bootstrap.cfg run.kaem
-chmod +x run2.kaem
+chmod 755 run2.kaem
 
 kaem --file run2.kaem


### PR DESCRIPTION
This is a small follow-up fix for https://github.com/fosslinux/live-bootstrap/pull/171.

It seems that `chmod +x` doesn't work as expected at this stage of the bootstrap, and instead removes all file permissions. This prevents rootless bootstrap from working, but doesn't seem to affect other bootstrap modes.