### PR TITLE
Add a rootless bootstrap mode using bubblewrap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,13 +23,15 @@ Get me started!
    installed.
 
    a. Alternatively, run ``./rootfs.py --chroot`` to run it in a chroot.
-   b. Alternatively, run ``./rootfs.py`` but don’t run the actual
+   b. Alternatively, run ``./rootfs.py --bwrap`` to run it in a bubblewrap
+      sandbox. When user namespaces are supported, this mode is rootless.
+   c. Alternatively, run ``./rootfs.py`` but don’t run the actual
       virtualization and instead copy sysa/tmp/initramfs to a USB or
       some other device and boot from bare metal. NOTE: we now require
       a hard drive. This is currently hardcoded as sda. You also need
       to put ``sysc/tmp/disk.img`` onto your sda on the bootstrapping
       machine.
-   c. Alternatively, do not use python at all, see "Python-less build"
+   d. Alternatively, do not use python at all, see "Python-less build"
       below.
 
 5. Wait.

--- a/lib/sysgeneral.py
+++ b/lib/sysgeneral.py
@@ -3,11 +3,13 @@
 This file contains a few functions to be shared by all Sys* classes
 """
 
+# SPDX-FileCopyrightText: 2022 Dor Askayo <dor.askayo@gmail.com>
 # SPDX-FileCopyrightText: 2021-22 fosslinux <fosslinux@aussies.space>
 # SPDX-FileCopyrightText: 2021 Andrius Štikonas <andrius@stikonas.eu>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
+import shutil
 import hashlib
 import glob
 import subprocess
@@ -33,10 +35,20 @@ class SysGeneral:
     mounted_tmpfs = False
 
     def __del__(self):
-        if self.mounted_tmpfs and not self.preserve_tmp:
+        if not self.preserve_tmp:
+            self.remove_tmp()
+
+    def remove_tmp(self):
+        """Remove the tmp directory"""
+        if self.tmp_dir is None:
+            return
+
+        if self.mounted_tmpfs:
             print(f"Unmounting tmpfs from {self.tmp_dir}")
             umount(self.tmp_dir)
-            os.rmdir(self.tmp_dir)
+
+        print(f"Removing {self.tmp_dir}")
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def mount_tmpfs(self):
         """Mount the tmpfs for this sysx"""

--- a/rootfs.py
+++ b/rootfs.py
@@ -45,7 +45,7 @@ def main():
                         default="x86")
     parser.add_argument("-c", "--chroot", help="Run inside chroot",
                         action="store_true")
-    parser.add_argument("-p", "--preserve", help="Do not unmount temporary dir",
+    parser.add_argument("-p", "--preserve", help="Do not remove temporary dir",
                         action="store_true")
     parser.add_argument("-t", "--tmpdir", help="Temporary directory")
     parser.add_argument("--force-timestamps",
@@ -128,8 +128,10 @@ print(shutil.which('chroot'))
         chroot_binary = run('sudo', 'python3', '-c', find_chroot,
                             capture_output=True).stdout.decode().strip()
 
-        system_c.prepare(create_disk_image=False)
-        system_a.prepare(copy_sysc=True,
+        system_c.prepare(mount_tmpfs=True,
+                         create_disk_image=False)
+        system_a.prepare(mount_tmpfs=True,
+                         copy_sysc=True,
                          create_initramfs=False)
 
         # sysa
@@ -141,8 +143,10 @@ print(shutil.which('chroot'))
         if os.path.isdir('kritis-linux'):
             shutil.rmtree('kritis-linux')
 
-        system_c.prepare(create_disk_image=True)
-        system_a.prepare(copy_sysc=False,
+        system_c.prepare(mount_tmpfs=True,
+                         create_disk_image=True)
+        system_a.prepare(mount_tmpfs=True,
+                         copy_sysc=False,
                          create_initramfs=True)
 
         run('git', 'clone',
@@ -162,8 +166,10 @@ print(shutil.which('chroot'))
             '--log', '/tmp/bootstrap.log')
 
     elif args.bare_metal:
-        system_c.prepare(create_disk_image=True)
-        system_a.prepare(copy_sysc=False,
+        system_c.prepare(mount_tmpfs=True,
+                         create_disk_image=True)
+        system_a.prepare(mount_tmpfs=True,
+                         copy_sysc=False,
                          create_initramfs=True)
 
         print("Please:")
@@ -171,8 +177,10 @@ print(shutil.which('chroot'))
         print("  2. Take sysc/tmp/disk.img and put this on a writable storage medium.")
 
     else:
-        system_c.prepare(create_disk_image=True)
-        system_a.prepare(copy_sysc=False,
+        system_c.prepare(mount_tmpfs=True,
+                         create_disk_image=True)
+        system_a.prepare(mount_tmpfs=True,
+                         copy_sysc=False,
                          create_initramfs=True)
 
         run(args.qemu_cmd,

--- a/rootfs.py
+++ b/rootfs.py
@@ -110,8 +110,7 @@ def main():
 
     system_c = SysC(arch=args.arch, preserve_tmp=args.preserve,
             tmpdir=args.tmpdir, chroot=args.chroot)
-    system_b = SysB(arch=args.arch, preserve_tmp=args.preserve,
-            chroot=args.chroot)
+    system_b = SysB(arch=args.arch, preserve_tmp=args.preserve)
     system_a = SysA(arch=args.arch, preserve_tmp=args.preserve,
                     tmpdir=args.tmpdir, chroot=args.chroot,
                     sysb_dir=system_b.sys_dir, sysc_tmp=system_c.tmp_dir)

--- a/sysa.py
+++ b/sysa.py
@@ -17,7 +17,7 @@ class SysA(SysGeneral):
     Class responsible for preparing sources for System A.
     """
     # pylint: disable=too-many-instance-attributes,too-many-arguments
-    def __init__(self, arch, preserve_tmp, tmpdir, chroot, sysb_dir, sysc_tmp):
+    def __init__(self, arch, preserve_tmp, tmpdir, sysb_dir, sysc_tmp):
         self.git_dir = os.path.dirname(os.path.join(__file__))
         self.arch = arch
         self.preserve_tmp = preserve_tmp
@@ -33,8 +33,6 @@ class SysA(SysGeneral):
         self.cache_dir = os.path.join(self.sys_dir, 'distfiles')
         self.sysb_dir = sysb_dir
         self.sysc_tmp = sysc_tmp
-
-        self.prepare(chroot, not chroot)
 
     def prepare(self, copy_sysc, create_initramfs):
         """

--- a/sysa.py
+++ b/sysa.py
@@ -36,9 +36,6 @@ class SysA(SysGeneral):
 
         self.prepare(chroot)
 
-        if not chroot:
-            self.make_initramfs()
-
     def prepare(self, chroot):
         """
         Prepare directory structure for System A.
@@ -55,6 +52,8 @@ class SysA(SysGeneral):
 
         if chroot:
             self.sysc()
+        else:
+            self.make_initramfs()
 
     def sysa(self):
         """Copy in sysa files for sysa."""

--- a/sysa.py
+++ b/sysa.py
@@ -34,9 +34,9 @@ class SysA(SysGeneral):
         self.sysb_dir = sysb_dir
         self.sysc_tmp = sysc_tmp
 
-        self.prepare(chroot)
+        self.prepare(chroot, not chroot)
 
-    def prepare(self, chroot):
+    def prepare(self, copy_sysc, create_initramfs):
         """
         Prepare directory structure for System A.
         We create an empty tmpfs, unpack stage0-posix.
@@ -50,9 +50,10 @@ class SysA(SysGeneral):
         # sysb must be added to sysa as it is another initramfs stage
         self.sysb()
 
-        if chroot:
+        if copy_sysc:
             self.sysc()
-        else:
+
+        if create_initramfs:
             self.make_initramfs()
 
     def sysa(self):

--- a/sysa.py
+++ b/sysa.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """System A"""
 # SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Dor Askayo <dor.askayo@gmail.com>
 # SPDX-FileCopyrightText: 2021 Andrius Štikonas <andrius@stikonas.eu>
 # SPDX-FileCopyrightText: 2021 Melg Eight <public.melg8@gmail.com>
 # SPDX-FileCopyrightText: 2021-22 fosslinux <fosslinux@aussies.space>
@@ -27,20 +28,22 @@ class SysA(SysGeneral):
             self.tmp_dir = os.path.join(self.git_dir, 'tmp')
         else:
             self.tmp_dir = os.path.join(tmpdir, 'sysa')
-            os.mkdir(self.tmp_dir)
         self.sysa_dir = os.path.join(self.tmp_dir, 'sysa')
         self.base_dir = self.sysa_dir
         self.cache_dir = os.path.join(self.sys_dir, 'distfiles')
         self.sysb_dir = sysb_dir
         self.sysc_tmp = sysc_tmp
 
-    def prepare(self, copy_sysc, create_initramfs):
+    def prepare(self, mount_tmpfs, copy_sysc, create_initramfs):
         """
         Prepare directory structure for System A.
-        We create an empty tmpfs, unpack stage0-posix.
+        We create an empty tmp directory, unpack stage0-posix.
         Rest of the files are unpacked into more structured directory /sysa
         """
-        self.mount_tmpfs()
+        if mount_tmpfs:
+            self.mount_tmpfs()
+        else:
+            os.mkdir(self.tmp_dir)
 
         self.stage0_posix()
         self.sysa()

--- a/sysa.py
+++ b/sysa.py
@@ -33,14 +33,13 @@ class SysA(SysGeneral):
         self.cache_dir = os.path.join(self.sys_dir, 'distfiles')
         self.sysb_dir = sysb_dir
         self.sysc_tmp = sysc_tmp
-        self.chroot = chroot
 
-        self.prepare()
+        self.prepare(chroot)
 
         if not chroot:
             self.make_initramfs()
 
-    def prepare(self):
+    def prepare(self, chroot):
         """
         Prepare directory structure for System A.
         We create an empty tmpfs, unpack stage0-posix.
@@ -54,7 +53,7 @@ class SysA(SysGeneral):
         # sysb must be added to sysa as it is another initramfs stage
         self.sysb()
 
-        if self.chroot:
+        if chroot:
             self.sysc()
 
     def sysa(self):

--- a/sysb.py
+++ b/sysb.py
@@ -12,10 +12,9 @@ class SysB(SysGeneral):
     """
     Class responsible for preparing sources for System B.
     """
-    def __init__(self, arch, preserve_tmp, chroot):
+    def __init__(self, arch, preserve_tmp):
         self.git_dir = os.path.dirname(os.path.join(__file__))
         self.arch = arch
         self.preserve_tmp = preserve_tmp
-        self.chroot = chroot
 
         self.sys_dir = os.path.join(self.git_dir, 'sysb')

--- a/sysc.py
+++ b/sysc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """System C"""
 # SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Dor Askayo <dor.askayo@gmail.com>
 # SPDX-FileCopyrightText: 2021-22 fosslinux <fosslinux@aussies.space>
 # SPDX-FileCopyrightText: 2021 Andrius Štikonas <andrius@stikonas.eu>
 
@@ -31,7 +32,6 @@ class SysC(SysGeneral):
             self.tmp_dir = os.path.join(self.sys_dir, 'tmp')
         else:
             self.tmp_dir = os.path.join(tmpdir, 'sysc')
-            os.mkdir(self.tmp_dir)
 
     def __del__(self):
         if not self.preserve_tmp:
@@ -41,11 +41,14 @@ class SysC(SysGeneral):
 
         super().__del__()
 
-    def prepare(self, create_disk_image):
+    def prepare(self, mount_tmpfs, create_disk_image):
         """
         Prepare directory structure for System C.
         """
-        self.mount_tmpfs()
+        if mount_tmpfs:
+            self.mount_tmpfs()
+        else:
+            os.mkdir(self.tmp_dir)
 
         rootfs_dir = None
 

--- a/sysc.py
+++ b/sysc.py
@@ -33,7 +33,7 @@ class SysC(SysGeneral):
             self.tmp_dir = os.path.join(tmpdir, 'sysc')
             os.mkdir(self.tmp_dir)
 
-        self.prepare(chroot)
+        self.prepare(not chroot)
 
     def __del__(self):
         if not self.preserve_tmp:
@@ -43,7 +43,7 @@ class SysC(SysGeneral):
 
         super().__del__()
 
-    def prepare(self, chroot):
+    def prepare(self, create_disk_image):
         """
         Prepare directory structure for System C.
         """
@@ -51,7 +51,7 @@ class SysC(SysGeneral):
 
         rootfs_dir = None
 
-        if not chroot:
+        if create_disk_image:
             # Create + mount a disk for QEMU to use
             disk_path = os.path.join(self.tmp_dir, 'disk.img')
             self.dev_name = create_disk(disk_path, "msdos", "ext4", '8G')
@@ -68,8 +68,8 @@ class SysC(SysGeneral):
 
         copytree(self.sys_dir, rootfs_dir, ignore=shutil.ignore_patterns("tmp"))
 
-        # Unmount tmp/mnt if it exists
-        if not chroot:
+        # Unmount tmp/mnt if it was mounted
+        if create_disk_image:
             umount(rootfs_dir)
 
     # pylint: disable=line-too-long,too-many-statements

--- a/sysc.py
+++ b/sysc.py
@@ -49,26 +49,29 @@ class SysC(SysGeneral):
         Prepare directory structure for System C.
         """
         self.mount_tmpfs()
+
+        rootfs_dir = None
+
         if not self.chroot:
             # Create + mount a disk for QEMU to use
             disk_path = os.path.join(self.tmp_dir, 'disk.img')
             self.dev_name = create_disk(disk_path, "msdos", "ext4", '8G')
-            self.rootfs_dir = os.path.join(self.tmp_dir, 'mnt')
-            os.mkdir(self.rootfs_dir)
-            mount(self.dev_name + "p1", self.rootfs_dir, 'ext4')
+            rootfs_dir = os.path.join(self.tmp_dir, 'mnt')
+            os.mkdir(rootfs_dir)
+            mount(self.dev_name + "p1", rootfs_dir, 'ext4')
             # Use chown to allow executing user to access it
             run('sudo', 'chown', getpass.getuser(), self.dev_name)
-            run('sudo', 'chown', getpass.getuser(), self.rootfs_dir)
+            run('sudo', 'chown', getpass.getuser(), rootfs_dir)
         else:
-            self.rootfs_dir = self.tmp_dir
+            rootfs_dir = self.tmp_dir
 
         self.get_packages()
 
-        copytree(self.sys_dir, self.rootfs_dir, ignore=shutil.ignore_patterns("tmp"))
+        copytree(self.sys_dir, rootfs_dir, ignore=shutil.ignore_patterns("tmp"))
 
         # Unmount tmp/mnt if it exists
         if not self.chroot:
-            umount(self.rootfs_dir)
+            umount(rootfs_dir)
 
     # pylint: disable=line-too-long,too-many-statements
     def get_packages(self):

--- a/sysc.py
+++ b/sysc.py
@@ -20,7 +20,7 @@ class SysC(SysGeneral):
     dev_name = None
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, arch, preserve_tmp, tmpdir, chroot):
+    def __init__(self, arch, preserve_tmp, tmpdir):
         self.git_dir = os.path.dirname(os.path.join(__file__))
         self.arch = arch
         self.preserve_tmp = preserve_tmp
@@ -32,8 +32,6 @@ class SysC(SysGeneral):
         else:
             self.tmp_dir = os.path.join(tmpdir, 'sysc')
             os.mkdir(self.tmp_dir)
-
-        self.prepare(not chroot)
 
     def __del__(self):
         if not self.preserve_tmp:

--- a/sysc.py
+++ b/sysc.py
@@ -38,9 +38,8 @@ class SysC(SysGeneral):
             if not self.chroot:
                 print(f"Deleting {self.dev_name}")
                 run('sudo', 'losetup', '-d', self.dev_name)
-            print(f"Unmounting tmpfs from {self.tmp_dir}")
-            umount(self.tmp_dir)
-            os.rmdir(self.tmp_dir)
+
+        super().__del__()
 
     def prepare(self):
         """

--- a/sysc.py
+++ b/sysc.py
@@ -24,7 +24,6 @@ class SysC(SysGeneral):
         self.git_dir = os.path.dirname(os.path.join(__file__))
         self.arch = arch
         self.preserve_tmp = preserve_tmp
-        self.chroot = chroot
 
         self.sys_dir = os.path.join(self.git_dir, 'sysc')
         self.cache_dir = os.path.join(self.sys_dir, 'distfiles')
@@ -34,7 +33,7 @@ class SysC(SysGeneral):
             self.tmp_dir = os.path.join(tmpdir, 'sysc')
             os.mkdir(self.tmp_dir)
 
-        self.prepare()
+        self.prepare(chroot)
 
     def __del__(self):
         if not self.preserve_tmp:
@@ -44,7 +43,7 @@ class SysC(SysGeneral):
 
         super().__del__()
 
-    def prepare(self):
+    def prepare(self, chroot):
         """
         Prepare directory structure for System C.
         """
@@ -52,7 +51,7 @@ class SysC(SysGeneral):
 
         rootfs_dir = None
 
-        if not self.chroot:
+        if not chroot:
             # Create + mount a disk for QEMU to use
             disk_path = os.path.join(self.tmp_dir, 'disk.img')
             self.dev_name = create_disk(disk_path, "msdos", "ext4", '8G')
@@ -70,7 +69,7 @@ class SysC(SysGeneral):
         copytree(self.sys_dir, rootfs_dir, ignore=shutil.ignore_patterns("tmp"))
 
         # Unmount tmp/mnt if it exists
-        if not self.chroot:
+        if not chroot:
             umount(rootfs_dir)
 
     # pylint: disable=line-too-long,too-many-statements

--- a/sysc.py
+++ b/sysc.py
@@ -16,6 +16,9 @@ class SysC(SysGeneral):
     """
     Class responsible for preparing sources for System C.
     """
+
+    dev_name = None
+
     # pylint: disable=too-many-instance-attributes
     def __init__(self, arch, preserve_tmp, tmpdir, chroot):
         self.git_dir = os.path.dirname(os.path.join(__file__))
@@ -35,8 +38,8 @@ class SysC(SysGeneral):
 
     def __del__(self):
         if not self.preserve_tmp:
-            if not self.chroot:
-                print(f"Deleting {self.dev_name}")
+            if self.dev_name is not None:
+                print(f"Detaching {self.dev_name}")
                 run('sudo', 'losetup', '-d', self.dev_name)
 
         super().__del__()


### PR DESCRIPTION
This PR adds the ability to bootstrap using the `bwrap` utility, which can operate in rootless mode when user namespaces are supported.

Most of the commits in this PR rework the Python scripts to allow better integration of additional bootstrap modes, and some fix existing issues. The most significant change is that the `prepare()` methods of sysa and sysc are now called directly from `rootfs.py`, and provided with the configuration that each bootstrap mode expects.

See commit messages for more information.