### PR TITLE
Rebuild false.c in coreutils 5.

### DIFF
--- a/sysa/coreutils-5.0/coreutils-5.0.kaem
+++ b/sysa/coreutils-5.0/coreutils-5.0.kaem
@@ -27,6 +27,8 @@ catm config.h
 # We will rebuild it
 rm src/false.c
 
+rm src/dircolors.h
+
 patch -Np0 -i ../../patches/modechange.patch
 patch -Np0 -i ../../patches/mbstate.patch
 patch -Np0 -i ../../patches/ls-strcmp.patch

--- a/sysa/coreutils-5.0/coreutils-5.0.kaem
+++ b/sysa/coreutils-5.0/coreutils-5.0.kaem
@@ -24,6 +24,9 @@ cp lib/ftw_.h lib/ftw.h
 cp lib/search_.h lib/search.h
 catm config.h
 
+# We will rebuild it
+rm src/false.c
+
 patch -Np0 -i ../../patches/modechange.patch
 patch -Np0 -i ../../patches/mbstate.patch
 patch -Np0 -i ../../patches/ls-strcmp.patch

--- a/sysa/coreutils-5.0/coreutils-5.0.sh
+++ b/sysa/coreutils-5.0/coreutils-5.0.sh
@@ -12,6 +12,9 @@ src_prepare() {
     cp lib/search_.h lib/search.h
     touch config.h
 
+    # Rebuild pregenerated file
+    rm -f src/false.c
+
     # Bison pre-generated file
     rm lib/getdate.c
 

--- a/sysa/coreutils-5.0/coreutils-5.0.sh
+++ b/sysa/coreutils-5.0/coreutils-5.0.sh
@@ -15,6 +15,8 @@ src_prepare() {
     # Rebuild pregenerated file
     rm -f src/false.c
 
+    rm -f src/dircolors.h
+
     # Bison pre-generated file
     rm lib/getdate.c
 

--- a/sysa/coreutils-5.0/mk/main.mk
+++ b/sysa/coreutils-5.0/mk/main.mk
@@ -86,6 +86,13 @@ LIB_SRC = acl posixtm posixver strftime getopt getopt1 hash hash-pjw addext argm
 
 LIB_OBJECTS = $(addprefix $(LIB_DIR)/, $(addsuffix .o, $(LIB_SRC)))
 
+$(SRC_DIR)/false.c: $(SRC_DIR)/true.c
+	cp $< $@
+	sed -i -e s/true/false/g \
+          -e s/success/failure/g \
+          -e 's/(EXIT_SUCCESS)/(EXIT_FAILURE)/g' \
+          $@
+
 $(LIB_DIR)/libfettish.a: $(LIB_OBJECTS)
 	$(AR) cr $@ $^
 

--- a/sysa/coreutils-5.0/mk/pass2.mk
+++ b/sysa/coreutils-5.0/mk/pass2.mk
@@ -96,6 +96,13 @@ LIB_SRC = acl alloca posixtm posixver strftime getopt getopt1 hash hash-pjw adde
 
 LIB_OBJECTS = $(addprefix $(LIB_DIR)/, $(addsuffix .o, $(LIB_SRC)))
 
+$(SRC_DIR)/false.c: $(SRC_DIR)/true.c
+	cp $< $@
+	sed -i -e s/true/false/g \
+          -e s/success/failure/g \
+          -e 's/(EXIT_SUCCESS)/(EXIT_FAILURE)/g' \
+          $@
+
 $(LIB_DIR)/libfettish.a: $(LIB_OBJECTS)
 	$(AR) cr $@ $^
 


### PR DESCRIPTION
This was spotted in #176.

Note that coreutils 8.32 does not need to rebuild false.c as it
implements it via compile-time #defines.

Fixes #176.