### PR TITLE
Create tmpdir before bootstrap

### DIFF
--- a/rootfs.py
+++ b/rootfs.py
@@ -129,6 +129,9 @@ def main():
                     tmpdir=args.tmpdir, external_sources=args.external_sources,
                     sysb_dir=system_b.sys_dir, sysc_dir=system_c.sys_dir)
 
+    if args.tmpdir is not None:
+        os.makedirs(args.tmpdir, exist_ok=True)
+
     bootstrap(args, system_a, system_b, system_c)
 
 def bootstrap(args, system_a, system_b, system_c):


### PR DESCRIPTION
Currently, the directory specified in `--tmpdir` has to be created by the user manually before executing `rootfs.py`.

This is a small quality-of-life change to remove this requirement.