### PR TITLE
Remove misplaced commands. These are run later in the script.

### DIFF
--- a/sysa/gzip-1.2.4/gzip-1.2.4.kaem
+++ b/sysa/gzip-1.2.4/gzip-1.2.4.kaem
@@ -11,9 +11,6 @@ set -ex
 mkdir build src
 cd build
 
-catm gzip.c.new ../../files/stat_override.c gzip.c
-cp gzip.c.new gzip.c
-
 # Extract
 ungz --file ${distfiles}/${pkg}.tar.gz --output ../src/${pkg}.tar
 untar --file ../src/${pkg}.tar


### PR DESCRIPTION
Remove commands that are run from the wrong directory, but currently do not fail because open (from M2libc) is incorrectly returning -2 when trying to open a non-existent file. Open has been fixed in M2libc so these commands need to be removed before updating the submodule with M2libc or they will produce an error. These commands are duplicates of the correct ones that run later in the script.