### PR TITLE
Improve reproduciblity of some packages

### DIFF
--- a/sysc/bash-5.1/bash-5.1.sh
+++ b/sysc/bash-5.1/bash-5.1.sh
@@ -21,11 +21,17 @@ src_prepare() {
 
 src_configure() {
     # --build argument needed for reproducibility
+    # bash_cv_dev_stdin and bash_cv_dev_fd are also used to
+    # improve reproducibility because they make configure
+    # skip checking for /dev/{fd,stdin,stdout,stderr} (build
+    # output is affected by their availability otherwise).
     ./configure --prefix="${PREFIX}" \
         --without-bash-malloc \
         --disable-nls \
         --build=i386-unknown-linux-musl \
-        --enable-static-link
+        --enable-static-link \
+        bash_cv_dev_stdin=absent \
+        bash_cv_dev_fd=whacky
 }
 
 src_install() {

--- a/sysc/coreutils-8.32/coreutils-8.32.sh
+++ b/sysc/coreutils-8.32/coreutils-8.32.sh
@@ -31,9 +31,14 @@ src_prepare() {
 src_configure() {
     # FORCE_UNSAFE_CONFIGURE disables "you should not run configure as root"
     # error from configuration system of coreutils.
+    # gl_cv_func_getcwd_path_max is set to improve reproducibility.
+    # In some environments, the configure script would set it to
+    # "no, but it is partly working", and in others it would set it
+    # to "yes", producing different build outputs.
     FORCE_UNSAFE_CONFIGURE=1 ./configure CFLAGS="-static" \
         --prefix="${PREFIX}" \
-        --build=i386-unknown-linux-musl
+        --build=i386-unknown-linux-musl \
+        gl_cv_func_getcwd_path_max="no, but it is partly working"
 }
 
 src_compile() {

--- a/sysc/perl-5.32.1/perl-5.32.1.sh
+++ b/sysc/perl-5.32.1/perl-5.32.1.sh
@@ -50,4 +50,8 @@ src_install() {
     # Remove messed up manpages
     rm "${DESTDIR}/"*.0
     rm "${DESTDIR}${PREFIX}/lib/perl5/5.32.1/pod/perldebguts.pod"
+
+    # Improve reproducibility. hostcat might be empty or set to "cat /etc/hosts"
+    # depending on whether /etc/hosts was available during the build.
+    sed -i "s_^hostcat='.*'\$_hostcat=''_g" "${DESTDIR}${PREFIX}/lib/perl5/5.32.1/i386-linux/Config_heavy.pl"
 }

--- a/sysc/tar-1.34/tar-1.34.sh
+++ b/sysc/tar-1.34/tar-1.34.sh
@@ -16,9 +16,14 @@ src_prepare() {
 }
 
 src_configure() {
+    # gl_cv_func_getcwd_path_max is set to improve reproducibility.
+    # In some environments, the configure script would set it to
+    # "no, but it is partly working", and in others it would set it
+    # to "yes", producing different build outputs.
     FORCE_UNSAFE_CONFIGURE=1 ./configure \
         --prefix="${PREFIX}" \
-        --disable-nls
+        --disable-nls \
+        gl_cv_func_getcwd_path_max="no, but it is partly working"
 }
 
 src_compile() {


### PR DESCRIPTION
I figure these out when trying to run the build in docker, which provides an environment slightly different to the one used when building in qemu/chroot/bwrap with rootfs.py