### PR TITLE
Support building only sysa with chroot mode

### DIFF
--- a/rootfs.py
+++ b/rootfs.py
@@ -31,6 +31,7 @@ def create_configuration_file(args):
     with open(config_path, "w", encoding="utf_8") as config:
         config.write("FORCE_TIMESTAMPS=" + str(args.force_timestamps) + "\n")
         config.write("CHROOT=" + str(args.chroot or args.bwrap) + "\n")
+        config.write("CHROOT_ONLY_SYSA=False\n")
         config.write("UPDATE_CHECKSUMS=" + str(args.update_checksums) + "\n")
         config.write("DISK=sda1\n")
 

--- a/sysa/run.sh
+++ b/sysa/run.sh
@@ -250,4 +250,6 @@ fi
 # In chroot mode transition directly into System C.
 SYSC=/sysc_image
 sys_transfer "${SYSC}" /sysc gzip patch
-exec chroot "${SYSC}" /init
+if [ "${CHROOT_ONLY_SYSA}" != True ]; then
+    exec chroot "${SYSC}" /init
+fi


### PR DESCRIPTION
This is intended primarily for external build systemss that directly bind into sysa and sysc rather than using rootfs Python wrapper. Part of https://github.com/fosslinux/live-bootstrap/issues/230