### PR TITLE
cosmetic fix for --force-timestamps, avoid touching other filesystems

### DIFF
--- a/sysa/helpers.sh
+++ b/sysa/helpers.sh
@@ -460,7 +460,7 @@ default() {
 # This function needs `touch` that supports --no-dereference
 # (at least coreutils 8.1).
 canonicalise_all_files_timestamp() {
-    find / -exec touch --no-dereference -t 197001010000.00 {} +
+    find / -xdev -exec touch --no-dereference -t 197001010000.00 {} +
 }
 
 populate_device_nodes() {


### PR DESCRIPTION
by using find-option -xdev and so: do not try to operate on e.g. /proc which avoid messages like:

touch: setting times of '/proc/fs/nfsd': Operation not permitted
touch: setting times of '/proc/1': Operation not permitted

closes #264