### PR TITLE
Add `-f` flag to curl download commands

### DIFF
--- a/download-distfiles.sh
+++ b/download-distfiles.sh
@@ -15,7 +15,7 @@ download_source() {
     local dest_path="${distfiles}/${fname}"
     if ! [ -e "${dest_path}" ]; then
         echo "Downloading ${fname}"
-        curl -L "${url}" --output "${dest_path}"
+        curl --fail --location "${url}" --output "${dest_path}"
     fi
     echo "${checksum}  ${dest_path}" | sha256sum -c
 }

--- a/sysa/helpers.sh
+++ b/sysa/helpers.sh
@@ -208,7 +208,7 @@ interpret_source_line() {
     # Default to basename of url if not given
     fname="${fname:-$(basename "${url}")}"
     if ! [ -e "${fname}" ]; then
-        curl -L "${url}" --output "${fname}"
+        curl --fail --location "${url}" --output "${fname}"
     fi
     echo "${checksum}  ${fname}" > "${fname}.sum"
     sha256sum -c "${fname}.sum"


### PR DESCRIPTION
By default, curls downloads the HTML error page and exits with code 0 when a server replies with an HTTP error code (e.g., 404), causing a SHA256 mismatch afterwards.

Adding the `-f` flag makes curl exit with non-zero error code and print an error like "The requested URL returned error: 404", making it a bit easier to diagnose distfile download issues.