### PR TITLE
Update Fiwix to v1.4.0-lb3 to pull in timestamp improvements

### DIFF
--- a/sysa/fiwix-1.4.0-lb2/fiwix-1.4.0-lb2.checksums
+++ b/sysa/fiwix-1.4.0-lb2/fiwix-1.4.0-lb2.checksums
@@ -1,1 +1,0 @@
-0de298be5c0b00654ddb226c2e657d4fdd2fa0c613ffb3bb32c23c65d2257bf0  /boot/fiwix

--- a/sysa/fiwix-1.4.0-lb2/sources
+++ b/sysa/fiwix-1.4.0-lb2/sources
@@ -1,1 +1,0 @@
-https://github.com/rick-masters/Fiwix/releases/download/v1.4.0-lb2/fiwix-1.4.0-lb2.tar.gz 44fb14fb666dcf4f5abf7f49eb3f1d92436b9d7353daa23138ff21e9ec78e30f

--- a/sysa/fiwix-1.4.0-lb3/fiwix-1.4.0-lb3.checksums
+++ b/sysa/fiwix-1.4.0-lb3/fiwix-1.4.0-lb3.checksums
@@ -1,0 +1,1 @@
+eda65efb4ca7b1e37cb5e0872e8267251870cdf86b341e6d967c856a926cc3f5  /boot/fiwix

--- a/sysa/fiwix-1.4.0-lb3/fiwix-1.4.0-lb3.kaem
+++ b/sysa/fiwix-1.4.0-lb3/fiwix-1.4.0-lb3.kaem
@@ -18,9 +18,9 @@ cd build
 untar --file ../src/${pkg}.tar
 cd ${pkg}
 
-alias as="tcc -m32 -march=i386 -std=c89 -D__KERNEL__ -DMAX_PID_VALUE=64000000 -DCONFIG_MMAP2 -DCONFIG_64BIT_SYSCALLS -DCONFIG_KEXEC -DNR_PROCS=4096 -DCHILD_MAX=4096 -DOPEN_MAX=1536 -DNR_OPENS=1536 -DINIT_PROGRAM=\"/init\" -DUTS_SYSNAME=\"Linux\" -D__VERSION__=\"tcc\" -traditional -I/sysa/fiwix-1.4.0-lb2/build/fiwix-1.4.0-lb2/include"
+alias as="tcc -m32 -march=i386 -std=c89 -D__KERNEL__ -DMAX_PID_VALUE=64000000 -DCONFIG_MMAP2 -DNO_CONFIG_OFFSET64 -DCONFIG_64BIT_SYSCALLS -DCONFIG_KEXEC -DNR_PROCS=4096 -DCHILD_MAX=4096 -DOPEN_MAX=1536 -DNR_OPENS=1536 -DINIT_PROGRAM=\"/init\" -DUTS_SYSNAME=\"Linux\" -D__VERSION__=\"tcc\" -traditional -I/sysa/${pkg}/build/${pkg}/include"
 
-alias cc="tcc -m32 -march=i386 -std=c89 -D__KERNEL__ -DMAX_PID_VALUE=64000000 -DCONFIG_MMAP2 -DCONFIG_64BIT_SYSCALLS -DCONFIG_KEXEC -DNR_PROCS=4096 -DCHILD_MAX=4096 -DOPEN_MAX=1536 -DNR_OPENS=1536 -DINIT_PROGRAM=\"/init\" -DUTS_SYSNAME=\"Linux\" -D__VERSION__=\"tcc\" -I/sysa/fiwix-1.4.0-lb2/build/fiwix-1.4.0-lb2/include -O2 -fno-pie -fno-common -ffreestanding -Wall -Wstrict-prototypes"
+alias cc="tcc -m32 -march=i386 -std=c89 -D__KERNEL__ -DMAX_PID_VALUE=64000000 -DCONFIG_MMAP2 -DNO_CONFIG_OFFSET64 -DCONFIG_64BIT_SYSCALLS -DCONFIG_KEXEC -DNR_PROCS=4096 -DCHILD_MAX=4096 -DOPEN_MAX=1536 -DNR_OPENS=1536 -DINIT_PROGRAM=\"/init\" -DUTS_SYSNAME=\"Linux\" -D__VERSION__=\"tcc\" -I/sysa/${pkg}/build/${pkg}/include -O2 -fno-pie -fno-common -ffreestanding -Wall -Wstrict-prototypes"
 
 cd kernel
 as -c -o boot.o boot.S

--- a/sysa/fiwix-1.4.0-lb3/sources
+++ b/sysa/fiwix-1.4.0-lb3/sources
@@ -1,0 +1,1 @@
+https://github.com/rick-masters/Fiwix/releases/download/v1.4.0-lb3/fiwix-1.4.0-lb3.tar.gz 525a24e32571e574da76e2a8c898f4eab371dfb85302d545c498a21c8028283d

--- a/sysa/run.kaem
+++ b/sysa/run.kaem
@@ -57,7 +57,7 @@ fi
 
 if match x${BUILD_FIWIX} xTrue; then
     # The Fiwix kernel
-    pkg="fiwix-1.4.0-lb2"
+    pkg="fiwix-1.4.0-lb3"
     cd ${pkg}
     kaem --verbose --file ${pkg}.kaem
     cd ..


### PR DESCRIPTION
Resolves #307 

Also includes many hard drive fixes and many other minor fixes.