### PR TITLE
Clean environment when executing run.sh

### DIFF
--- a/sysb/init
+++ b/sysb/init
@@ -37,7 +37,10 @@ install_tar util-linux-2.19.1 0
 # Begin sysb bootstrapping process
 cd "${SOURCES}"
 
-echo "PREFIX=${PREFIX}" > .env
-echo "SOURCES=${SOURCES}" >> .env
+cat > .env <<- EOF
+export PATH=${PATH}
+PREFIX=${PREFIX}
+SOURCES=${SOURCES}
+EOF
 
 exec ./run.sh

--- a/sysb/init
+++ b/sysb/init
@@ -43,4 +43,4 @@ PREFIX=${PREFIX}
 SOURCES=${SOURCES}
 EOF
 
-exec ./run.sh
+exec env -i bash run.sh

--- a/sysc/init
+++ b/sysc/init
@@ -68,9 +68,9 @@ ln -s /usr/bin/bash /usr/bin/sh
 cd "${SOURCES}"
 
 cat > .env <<- EOF
-export PATH="${PREFIX}/bin:${PREFIX}/sbin"
-export HOME=/tmp
-export SOURCE_DATE_EPOCH=0
+export PATH=${PATH}
+export HOME=${HOME}
+export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 PREFIX=${PREFIX}
 LIBDIR=${LIBDIR}
 SOURCES=${SOURCES}

--- a/sysc/init
+++ b/sysc/init
@@ -81,4 +81,4 @@ MAKEJOBS=${MAKEJOBS}
 INTERNAL_CI=${INTERNAL_CI}
 EOF
 
-exec ./run.sh
+exec env -i bash run.sh

--- a/sysc/run.sh
+++ b/sysc/run.sh
@@ -62,4 +62,4 @@ fi
 
 build bash-5.2.15
 
-exec env -i PATH="${PATH}" HOME="${HOME}" SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" bash run2.sh
+exec env -i bash run2.sh


### PR DESCRIPTION
See commit messages for more information.

No change in package hashes. Tested with the `bwrap` bootstrap mode.