### PR TITLE
Avoid exporting variables

### DIFF
--- a/sysa/linux-headers-5.10.41/linux-headers-5.10.41.sh
+++ b/sysa/linux-headers-5.10.41/linux-headers-5.10.41.sh
@@ -23,7 +23,7 @@ src_compile() {
 }
 
 src_install() {
-    export base_dir="${PWD}"
+    base_dir="${PWD}"
     # We "compile" the headers here because it is easier
     for d in include/uapi arch/x86/include/uapi; do
         cd "${d}"

--- a/sysb/run.sh
+++ b/sysb/run.sh
@@ -75,7 +75,7 @@ if [ $(($(ls -l "/dev/${DISK}" | sed "s/.*, *//" | sed "s/ .*//") % 8)) -eq 0 ];
     mkfs.ext4 "/dev/${DISK}1"
     DISK="${DISK}1"
 fi
-echo "export DISK=${DISK}" >> /usr/src/bootstrap.cfg
+echo "DISK=${DISK}" >> /usr/src/bootstrap.cfg
 
 SYSC=/sysc
 

--- a/sysc/autogen-5.18.16/autogen-5.18.16.sh
+++ b/sysc/autogen-5.18.16/autogen-5.18.16.sh
@@ -15,13 +15,13 @@ src_prepare() {
 src_compile() {
 (
     set -e
-    export PKG_CONFIG_PATH="${LIBDIR}/pkgconfig"
+    declare -x PKG_CONFIG_PATH="${LIBDIR}/pkgconfig"
     sed -i "s/make install/make install DESTDIR=\${DESTDIR}/" bootstrap_tarball.sh
     sed -i "/make check/d" bootstrap_tarball.sh
-    export FINALPREFIX="${PREFIX}"
-    export GUILE_STATIC="--static"
-    export GNULIBDIR="${PWD}"/../gnulib-8f4538a5
-    export MAN_PAGE_DATE=1970-01-01
+    declare -x FINALPREFIX="${PREFIX}"
+    declare -x GUILE_STATIC="--static"
+    declare -x GNULIBDIR="${PWD}"/../gnulib-8f4538a5
+    declare -x MAN_PAGE_DATE=1970-01-01
 
     SKIP_MAIN=1 . ./bootstrap_tarball.sh
     prepare_tarball

--- a/sysc/openssl-1.1.1l/openssl-1.1.1l.sh
+++ b/sysc/openssl-1.1.1l/openssl-1.1.1l.sh
@@ -23,7 +23,7 @@ src_configure() {
 }
 
 src_compile() {
-    export SOURCE_DATE_EPOCH=1638831119
+    declare -x SOURCE_DATE_EPOCH=1638831119
     default
 }
 


### PR DESCRIPTION
Using `export` for variables that are relevant only to specific packages pollutes the build environment of every package that follows. This PR removes all the remaining cases.

See commit messages for more information. No change in package hashes.

Tested with both QEMU kernel bootstrap and bwrap bootstrap modes.