### PR TITLE
recompile tar and add gzip 1.12 for V1.0 roadmap

### DIFF
--- a/parts.rst
+++ b/parts.rst
@@ -1193,3 +1193,13 @@ to ensure the compiler is suitable for downstream consumption;
   really be handled by the libc, which is what most distributions do.
 * LTO now fully functions correctly, despite both the linker and the compiler
   being static binaries.
+
+tar 1.34 (pass 2)
+========
+
+Rebuild tar using the musl tool chain.
+
+gzip 1.12
+==========
+
+Build the latest version of gzip using the musl tool chain.

--- a/sysc/gzip-1.12/gzip-1.12.sh
+++ b/sysc/gzip-1.12/gzip-1.12.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2021 Andrius Štikonas <andrius@stikonas.eu>
+# SPDX-FileCopyrightText: 2021-22 fosslinux <fosslinux@aussies.space>
+# SPDX-FileCopyrightText: 2021 Paul Dersey <pdersey@gmail.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+ssrc_prepare() {
+    default
+}
+
+src_configure() {
+./configure --prefix=/usr
+}
+
+src_compile() {
+make "${MAKEJOBS}"
+}
+
+src_install() {
+    default
+}

--- a/sysc/gzip-1.12/sources
+++ b/sysc/gzip-1.12/sources
@@ -1,0 +1,1 @@
+https://mirrors.kernel.org/gnu/gzip/gzip-1.12.tar.gz ce5e03e519f637e1f814011ace35c4f87b33c0bbabeec35baf5fbd3479e91956

--- a/sysc/run2.sh
+++ b/sysc/run2.sh
@@ -128,6 +128,10 @@ build binutils-2.38 pass2.sh
 
 build gcc-13.1.0
 
+build tar-1.34 
+
+Build gzip-1.12 
+
 if [ "$FORCE_TIMESTAMPS" = True ] ; then
     echo 'Forcing all files timestamps to be 0 unix time.'
     canonicalise_all_files_timestamp


### PR DESCRIPTION
Recompile tar and add gzip 1.12 for V1.0 roadmap

Update parts.rst to add tar 1.34 pass 2 and gzip 1.12