### PR TITLE
Simplify - kexec preparations

### DIFF
--- a/sysa/kexec-fiwix-1.0/src/kexec-fiwix.c
+++ b/sysa/kexec-fiwix-1.0/src/kexec-fiwix.c
@@ -81,11 +81,11 @@ int main() {
 	char *bare_metal = getenv("BARE_METAL");
 	if (bare_metal != NULL && strcmp(bare_metal, "True") == 0)
 	{
-		sprintf(cmdline, "fiwix root=/dev/ram0 ramdisksize=%d initrd=fiwix.ext2 kexec_proto=linux kexec_size=67000 kexec_cmdline=\"init=/init\"", INITRD_MB * 1024);
+		sprintf(cmdline, "fiwix root=/dev/ram0 ramdisksize=%d initrd=fiwix.ext2 kexec_proto=linux kexec_size=280000 kexec_cmdline=\"init=/init\"", INITRD_MB * 1024);
 	}
 	else
 	{
-		sprintf(cmdline, "fiwix console=/dev/ttyS0 root=/dev/ram0 ramdisksize=%d initrd=fiwix.ext2 kexec_proto=linux kexec_size=67000 kexec_cmdline=\"init=/init console=ttyS0\"", INITRD_MB * 1024);
+		sprintf(cmdline, "fiwix console=/dev/ttyS0 root=/dev/ram0 ramdisksize=%d initrd=fiwix.ext2 kexec_proto=linux kexec_size=280000 kexec_cmdline=\"init=/init console=ttyS0\"", INITRD_MB * 1024);
 	}
 	char * boot_loader_name = "kexec-fiwix";
 


### PR DESCRIPTION
Largest change is supporting command execution as an input to the initramfs/kernel in `kexec-linux`. This avoids us writing the initramfs to the ramdisk, reducing duplicating it in memory.

also expand the ramdisk - this *will* be able to be shrunk in the future. I just don't want to introduce too many changes at once.

dep of #334 

no checksum changes, there will be one big checksum change in #334 