### PR TITLE
Rename tmpdir to target and always preserve it, dropping --preserve

### DIFF
--- a/.github/workflows/bwrap.yml
+++ b/.github/workflows/bwrap.yml
@@ -43,15 +43,15 @@ jobs:
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
       - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --preserve --cores 2 --internal-ci pass1
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass1
       - name: Archive created packages
         if: failure() # archive failed builds progress
         uses: actions/upload-artifact@v3
         with:
           name: packages
-          path: tmp/external/repo/**
+          path: target/external/repo/**
       - name: Tar pass1 image
-        run: tar -cf pass1_image.tar tmp
+        run: tar -cf pass1_image.tar target
       - name: Archive pass1_image
         uses: actions/upload-artifact@v3
         with:
@@ -96,15 +96,15 @@ jobs:
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
       - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --preserve --cores 2 --internal-ci pass2
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass2
       - name: Archive created packages
         if: failure() # archive failed builds progress
         uses: actions/upload-artifact@v3
         with:
           name: internal_packages_pass2
-          path: tmp/external/repo/**
+          path: target/external/repo/**
       - name: Tar pass2 image
-        run: tar -cf pass2_image.tar tmp
+        run: tar -cf pass2_image.tar target
       - name: Archive pass2_image
         uses: actions/upload-artifact@v3
         with:
@@ -149,10 +149,10 @@ jobs:
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
       - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --preserve --cores 2 --internal-ci pass3
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass3
       - name: Archive created packages
         if: always() # archive both failed and successful builds
         uses: actions/upload-artifact@v3
         with:
           name: packages
-          path: tmp/external/repo/**
+          path: target/external/repo/**

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pylint
         run: sudo pip3 install pylint
       - name: pylint
-        run: pylint rootfs.py lib/utils.py lib/generator.py lib/tmpdir.py --disable=duplicate-code
+        run: pylint rootfs.py lib/utils.py lib/generator.py lib/target.py --disable=duplicate-code
 
   shellcheck:
     name: Lint shell files


### PR DESCRIPTION
There is nothing temporary about our "tmpdir" - its sole purpose is to contain the final product of the bootstrap process. Thus, removing it at the end of bootstrap amounts to doing the entire process for nothing.

To remedy this, --tmpdir is renamed --target, keeping the -t short form, and defaulting to "target" instead of "tmp" to make its purpose clearer. The --preserve option is removed, as the target is now always preserved.