### PR TITLE
Avoid double slash (`//`) in generated scripts

### DIFF
--- a/seed/script-generator.c
+++ b/seed/script-generator.c
@@ -461,8 +461,10 @@ void output_call_script(FILE *out, char *type, char *name, int using_bash, int s
 		fputs("kaem --file ", out);
 	}
 	fputs("/steps/", out);
-	fputs(type, out);
-	fputs("/", out);
+	if (strlen(type) != 0) {
+		fputs(type, out);
+		fputs("/", out);
+	}
 	fputs(name, out);
 	fputs(".sh\n", out);
 }


### PR DESCRIPTION
e.g., put `bash /steps/1.sh` instead of `bash /steps//1.sh`