### PR TITLE
Smaller CI intermediate tarballs

### DIFF
--- a/.github/workflows/bwrap.yml
+++ b/.github/workflows/bwrap.yml
@@ -51,7 +51,7 @@ jobs:
           name: packages
           path: tmp/external/repo/**
       - name: Tar pass1 image
-        run: tar -cf pass1_image.tar tmp
+        run: tar -cf pass1_image.tar --exclude "tmp/external/distfiles" tmp
       - name: Archive pass1_image
         uses: actions/upload-artifact@v3
         with:
@@ -104,7 +104,7 @@ jobs:
           name: internal_packages_pass2
           path: tmp/external/repo/**
       - name: Tar pass2 image
-        run: tar -cf pass2_image.tar tmp
+        run: tar -cf pass2_image.tar --exclude "tmp/external/distfiles" tmp
       - name: Archive pass2_image
         uses: actions/upload-artifact@v3
         with:

--- a/steps/manifest
+++ b/steps/manifest
@@ -164,6 +164,7 @@ build: grep-3.7
 build: sed-4.8
 build: autogen-5.18.16
 build: musl-1.2.4
+jump: break ( INTERNAL_CI == pass1 ) # scripts are generated in pass1
 build: python-2.0.1
 build: python-2.0.1
 build: python-2.3.7
@@ -175,7 +176,6 @@ build: python-3.3.7
 build: python-3.4.10
 build: python-3.8.16
 build: python-3.11.1
-jump: break ( INTERNAL_CI == pass1 ) # scripts are generated in pass1
 build: gcc-10.4.0
 build: binutils-2.41
 build: gcc-13.1.0


### PR DESCRIPTION
- Move Python bootstrap from pass2 to pass3. Python bootstrap is relatively fast, and we have more than enough time in pass3 to include it there. OTOH, it generates large build artifacts, which needlessly blow up the pass2 tarball size.
- Exclude external/distfiles from stage tarballs. It will always get copied from the top-level distfiles directory, which in turn is reloaded from cache.