### PR TITLE
Smaller CI intermediate tarballs (option 2)

### DIFF
--- a/.github/workflows/bwrap.yml
+++ b/.github/workflows/bwrap.yml
@@ -43,15 +43,15 @@ jobs:
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
       - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --preserve --cores 2 --internal-ci pass1
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass1
       - name: Archive created packages
         if: failure() # archive failed builds progress
         uses: actions/upload-artifact@v3
         with:
           name: packages
-          path: tmp/external/repo/**
+          path: target/external/repo/**
       - name: Tar pass1 image
-        run: tar -cf pass1_image.tar tmp
+        run: tar -cf pass1_image.tar target
       - name: Archive pass1_image
         uses: actions/upload-artifact@v3
         with:
@@ -96,15 +96,15 @@ jobs:
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
       - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --preserve --cores 2 --internal-ci pass2
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass2
       - name: Archive created packages
         if: failure() # archive failed builds progress
         uses: actions/upload-artifact@v3
         with:
           name: internal_packages_pass2
-          path: tmp/external/repo/**
+          path: target/external/repo/**
       - name: Tar pass2 image
-        run: tar -cf pass2_image.tar tmp
+        run: tar -cf pass2_image.tar target
       - name: Archive pass2_image
         uses: actions/upload-artifact@v3
         with:
@@ -149,10 +149,10 @@ jobs:
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
       - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --preserve --cores 2 --internal-ci pass3
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass3
       - name: Archive created packages
         if: always() # archive both failed and successful builds
         uses: actions/upload-artifact@v3
         with:
           name: packages
-          path: tmp/external/repo/**
+          path: target/external/repo/**

--- a/.github/workflows/bwrap.yml
+++ b/.github/workflows/bwrap.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run seed bootstrap
         run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci start
       - name: Tar seed image
-        run: tar -cf seed_image.tar target
+        run: tar -cf seed_image.tar --exclude "target/external/distfiles" target
       - name: Archive seed_image
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bwrap.yml
+++ b/.github/workflows/bwrap.yml
@@ -42,21 +42,23 @@ jobs:
           path: |
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
-      - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass1
+      - name: Run seed bootstrap
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci start
+      - name: Tar seed image
+        run: tar -cf seed_image.tar target
+      - name: Archive seed_image
+        uses: actions/upload-artifact@v3
+        with:
+          name: seed_image
+          path: seed_image.tar
+      - name: Run pass1 bootstrap
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci continue
       - name: Archive created packages
-        if: failure() # archive failed builds progress
+        if: always() # archive both failed and successful builds
         uses: actions/upload-artifact@v3
         with:
-          name: packages
+          name: packages_pass1
           path: target/external/repo/**
-      - name: Tar pass1 image
-        run: tar -cf pass1_image.tar target
-      - name: Archive pass1_image
-        uses: actions/upload-artifact@v3
-        with:
-          name: internal_pass1_image
-          path: pass1_image.tar
 
   pass2:
     name: Run up to Python bootstrap under bubblewrap
@@ -72,12 +74,17 @@ jobs:
           # There is a strange bug(?) in nongnu, when you clone a git repository
           # against a commit != HEAD with depth=1, it errors out.
           fetch-depth: 0
-      - name: Get pass1_image
+      - name: Get seed_image
         uses: actions/download-artifact@v3
         with:
-          name: internal_pass1_image
-      - name: Extract pass1_image
-        run: tar -xf pass1_image.tar
+          name: seed_image
+      - name: Extract seed_image
+        run: tar -xf seed_image.tar
+      - name: Get pass1 packages
+        uses: actions/download-artifact@v3
+        with:
+          name: packages_pass1
+          path: target/external/repo-preseeded/
       - name: Query cache for sources
         id: cache
         uses: actions/cache/restore@v3
@@ -95,21 +102,16 @@ jobs:
           path: |
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
-      - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass2
+      - name: Preseed bootstrap with pass1
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci continue
+      - name: Run pass2 bootstrap
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci continue
       - name: Archive created packages
-        if: failure() # archive failed builds progress
+        if: always() # archive both failed and successful builds
         uses: actions/upload-artifact@v3
         with:
-          name: internal_packages_pass2
+          name: packages_pass2
           path: target/external/repo/**
-      - name: Tar pass2 image
-        run: tar -cf pass2_image.tar target
-      - name: Archive pass2_image
-        uses: actions/upload-artifact@v3
-        with:
-          name: internal_pass2_image
-          path: pass2_image.tar
 
   pass3:
     name: Run remaining builds under bubblewrap
@@ -125,12 +127,17 @@ jobs:
           # There is a strange bug(?) in nongnu, when you clone a git repository
           # against a commit != HEAD with depth=1, it errors out.
           fetch-depth: 0
-      - name: Get pass2_image
+      - name: Get seed_image
         uses: actions/download-artifact@v3
         with:
-          name: internal_pass2_image
-      - name: Extract pass2_image
-        run: tar -xf pass2_image.tar
+          name: seed_image
+      - name: Extract seed_image
+        run: tar -xf seed_image.tar
+      - name: Get pass2 packages
+        uses: actions/download-artifact@v3
+        with:
+          name: packages_pass2
+          path: target/external/repo-preseeded/
       - name: Query cache for sources
         id: cache
         uses: actions/cache/restore@v3
@@ -148,8 +155,12 @@ jobs:
           path: |
             distfiles
           key: cache-${{ hashFiles('steps/*/sources') }}
-      - name: Run bootstrap
-        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci pass3
+      - name: Preseed bootstrap with pass1
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci continue
+      - name: Preseed bootstrap with pass2
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci continue
+      - name: Run pass3 bootstrap
+        run: ./rootfs.py --bwrap --external-sources --build-kernels --cores 2 --internal-ci continue
       - name: Archive created packages
         if: always() # archive both failed and successful builds
         uses: actions/upload-artifact@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pylint
         run: sudo pip3 install pylint
       - name: pylint
-        run: pylint rootfs.py lib/utils.py lib/generator.py lib/tmpdir.py --disable=duplicate-code
+        run: pylint rootfs.py lib/utils.py lib/generator.py lib/target.py --disable=duplicate-code
 
   shellcheck:
     name: Lint shell files

--- a/rootfs.py
+++ b/rootfs.py
@@ -185,7 +185,7 @@ print(shutil.which('chroot'))
 
     elif args.bwrap:
         init = '/init'
-        if not args.internal_ci or args.internal_ci == "pass1":
+        if not args.internal_ci or args.internal_ci == "start":
             generator.prepare(target, using_kernel=False)
 
             arch = stage0_arch_map.get(args.arch, args.arch)

--- a/steps/manifest
+++ b/steps/manifest
@@ -50,6 +50,7 @@ build: heirloom-devtools-070527
 build: bash-2.05b
 improve: setup_repo
 improve: update_env
+jump: break ( INTERNAL_CI == start )
 build: flex-2.5.11
 build: tcc-0.9.27
 improve: musl_libdir
@@ -115,7 +116,7 @@ define: BUILD_LINUX = ( CHROOT == False || BUILD_KERNELS == True )
 build: kexec-linux-1.0.0 ( BUILD_LINUX == True )
 build: kexec-tools-2.0.22 ( BUILD_LINUX == True )
 build: linux-4.9.10 ( BUILD_LINUX == True )
-jump: break ( INTERNAL_CI == pass1 )
+jump: break ( INTERNAL_CI == start )
 jump: linux ( CHROOT == False )
 improve: finalize_fhs
 build: musl-1.2.4
@@ -175,7 +176,7 @@ build: python-3.3.7
 build: python-3.4.10
 build: python-3.8.16
 build: python-3.11.1
-jump: break ( INTERNAL_CI == pass1 ) # scripts are generated in pass1
+jump: break ( INTERNAL_CI == start )
 build: gcc-10.4.0
 build: binutils-2.41
 build: gcc-13.1.0


### PR DESCRIPTION
This is a different option for making CI tarballs smaller: we revert to using a small seed tarball, plus packages built in each pass. The seed tarball is built as early as possible (i.e. right after we have bash), everything beyond that is passed in the form of repo packages.

To make this work properly, in each pass, rootfs.py needs to be run once for each previous pass to preseed from, and once more for the current pass.