### PR TITLE
Fix "Bootstrapping" message being printed too late in bwrap runs

### DIFF
--- a/rootfs.py
+++ b/rootfs.py
@@ -168,7 +168,7 @@ def main():
 
 def bootstrap(args, generator, target, size):
     """Kick off bootstrap process."""
-    print(f"Bootstrapping {args.arch}")
+    print(f"Bootstrapping {args.arch}", flush=True)
     if args.chroot:
         find_chroot = """
 import shutil


### PR DESCRIPTION
This should be printed at the beginning, but instead is only shown at the end, due to output buffering - force an explicit flush.