### PR TITLE
 Create disk images without root 

### DIFF
--- a/lib/generator.py
+++ b/lib/generator.py
@@ -29,6 +29,7 @@ class Generator():
         self.external_sources = external_sources
         self.repo_path = repo_path
         self.source_manifest = self.get_source_manifest(not self.external_sources)
+        self.early_source_manifest = self.get_source_manifest(True)
         self.target_dir = None
         self.external_dir = None
 
@@ -159,9 +160,10 @@ class Generator():
 
     def distfiles(self):
         """Copy in distfiles"""
-        def copy_no_network_distfiles(out):
+        def copy_no_network_distfiles(out, early):
             # Note that "no disk" implies "no network" for kernel bootstrap mode
-            for file in self.source_manifest:
+            manifest = self.early_source_manifest if early else self.source_manifest
+            for file in manifest:
                 file = file[3].strip()
                 shutil.copy2(os.path.join(self.distfiles_dir, file),
                              os.path.join(out, file))
@@ -171,13 +173,13 @@ class Generator():
 
         if early_distfile_dir != main_distfile_dir:
             os.makedirs(early_distfile_dir, exist_ok=True)
-            copy_no_network_distfiles(early_distfile_dir)
+            copy_no_network_distfiles(early_distfile_dir, True)
 
         if self.external_sources:
             shutil.copytree(self.distfiles_dir, main_distfile_dir, dirs_exist_ok=True)
         else:
             os.mkdir(main_distfile_dir)
-            copy_no_network_distfiles(main_distfile_dir)
+            copy_no_network_distfiles(main_distfile_dir, False)
 
     @staticmethod
     def output_dir(srcfs_file, dirpath):

--- a/steps/jump/move_disk.sh
+++ b/steps/jump/move_disk.sh
@@ -22,7 +22,9 @@ while ! dd if=/dev/${DISK} of=/dev/null bs=512 count=1; do
 done
 
 # Create partition if it doesn't exist
-if [ $(($(stat -c "%Lr" "/dev/${DISK}") % 8)) -eq 0 ]; then
+# 'stat -c "%T"' prints the minor device type in hexadecimal.
+# The decimal version (with "%Lr") is not available in this version of stat.
+if [ $((0x$(stat -c "%T" "/dev/${DISK}") % 8)) -eq 0 ]; then
     echo "Creating partition table..."
     # Start at 1GiB, use -S32 -H64 to align to MiB rather than cylinder boundary
     echo "2097152;" | sfdisk -uS -S32 -H64 --force "/dev/${DISK}"


### PR DESCRIPTION
`mke2fs` has a `-d` option that allows to populate the newly created filesystem without needing to temporarily mount it. That allows to use `parted` and `mkfs.ext3` on regular files without needing root access.

I also fixed some issues I bumped into while testing (see commits).