### PR TITLE
Fix uninitialized variables in script-generator

### DIFF
--- a/seed/script-generator.c
+++ b/seed/script-generator.c
@@ -168,7 +168,7 @@ void output_config(FILE *out) {
 char *get_var(char *name) {
 	/* Search through existing variables. */
 	Variable *var;
-	Variable *last;
+	Variable *last = NULL;
 	for (var = variables; var != NULL; var = var->next) {
 		if (strcmp(name, var->name) == 0) {
 			return var->val;
@@ -373,7 +373,7 @@ int interpret(Directive *directive) {
 
 Directive *interpreter(Directive *directives) {
 	Directive *directive;
-	Directive *last;
+	Directive *last = NULL;
 	for (directive = directives; directive != NULL; directive = directive->next) {
 		if (interpret(directive)) {
 			/* This means this directive needs to be removed from the linked list. */


### PR DESCRIPTION
Not sure if the Variable *last one is significant, but the Directive *last can be triggered by having the first directive in the manifest be a define.