### PR TITLE
Restore multicore build support with kernel-bootstrap

### DIFF
--- a/rootfs.py
+++ b/rootfs.py
@@ -33,6 +33,7 @@ def create_configuration_file(args):
         config.write(f"UPDATE_CHECKSUMS={args.update_checksums}\n")
         config.write(f"JOBS={args.cores}\n")
         config.write(f"SWAP_SIZE={args.swap}\n")
+        config.write(f"FINAL_JOBS={args.cores}\n")
         config.write(f"INTERNAL_CI={args.internal_ci or False}\n")
         config.write(f"BARE_METAL={args.bare_metal}\n")
         if (args.bare_metal or args.qemu) and not args.kernel:

--- a/steps/improve/finalize_job_count.sh
+++ b/steps/improve/finalize_job_count.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# SPDX-FileCopyrightText: 2024 Gábor Stefanik <netrolller.3d@gmail.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Finalize job count once SMP support is available
+
+cat >> /steps/bootstrap.cfg <<- EOF
+JOBS=${FINAL_JOBS}
+EOF
+
+. /steps/bootstrap.cfg
+. /steps/env

--- a/steps/improve/update_env.sh
+++ b/steps/improve/update_env.sh
@@ -6,7 +6,7 @@
 
 unset GUILE_LOAD_PATH
 
-cat > /steps/env <<- EOF
+cat >> /steps/env <<- 'EOF'
 export PATH=${PREFIX}/bin
 PREFIX=${PREFIX}
 LIBDIR=${LIBDIR}

--- a/steps/manifest
+++ b/steps/manifest
@@ -119,6 +119,7 @@ build: linux-4.9.10 ( BUILD_LINUX == True )
 jump: break ( INTERNAL_CI == pass1 )
 jump: linux ( CHROOT == False )
 jump: move_disk ( KERNEL_BOOTSTRAP == True )
+improve: finalize_job_count
 improve: finalize_fhs
 improve: swap ( SWAP_SIZE != 0 )
 build: musl-1.2.4


### PR DESCRIPTION
This was removed as part of the simplify refactor, severely slowing down qemu and bare-metal builds. Restoring it brings us back to the same build times that we saw before the refactor.