### PR TITLE
Use devtmpfs, and improve finalize_fhs.sh

### DIFF
--- a/steps/improve/finalize_fhs.sh
+++ b/steps/improve/finalize_fhs.sh
@@ -6,13 +6,22 @@
 #
 # Add the rest of the FHS that we will use and is not created pre-boot
 rm -rf /sbin /usr/sbin
+ln -s /usr/bin /usr/sbin
 for d in bin lib sbin; do
-    ln -s "usr/${d}" "/${d}"
+    ln -s "/usr/${d}" "/${d}" || true # these might exist if rerunning
 done
-mkdir -p /etc /run /var
-test -d /proc || (mkdir /proc && mount -t proc proc /proc)
-test -d /sys || (mkdir /sys && mount -t sysfs sysfs /sys)
+
+mkdir -p /etc /run /var/log /var/lock /var/spool /var/tmp /var/cache
+
+# can't use /dev/null before mounting /dev
+mount | grep '/dev' &> /junk || (mkdir -p /dev; mount -t devtmpfs none /dev)
+rm /junk &> /dev/null || true
+
+mount | grep '/proc' &> /dev/null || (mkdir -p /proc; mount -t proc proc /proc)
+mount | grep '/sys' &> /dev/null || (mkdir -p /sys; mount -t sysfs sysfs /sys)
 # Make /tmp a ramdisk (speeds up configure etc significantly)
-test -d /tmp || (mkdir /tmp && mount -t tmpfs tmpfs /tmp)
+mount | grep '/tmp' &> /dev/null || (mkdir -p /tmp; mount -t tmpfs tmpfs /tmp)
+
 # Add /etc/resolv.conf
 echo 'nameserver 1.1.1.1' > /etc/resolv.conf
+echo 'nameserver 1.1.1.1' > /etc/resolv.conf.head

--- a/steps/jump/linux.sh
+++ b/steps/jump/linux.sh
@@ -16,7 +16,6 @@ if [ "${KERNEL_BOOTSTRAP}" = True ]; then
     find / -xdev -type d -printf "dir %p %m %U %G\n" >> /initramfs.list
     find / -xdev -type f -printf "file %p %p %m %U %G\n" >> /initramfs.list
     find / -xdev -type l -printf "slink %p %l %m %U %G\n" >> /initramfs.list
-    find / -xdev -type c -or -type b -not -name "ram*" -printf "nod %p %m %U %G %y " -exec stat -c '%Hr %Lr' {} \; >> /initramfs.list
     kexec-linux "/dev/ram1" "/boot/linux-4.9.10" "!$(command -v gen_init_cpio) /initramfs.list"
 else
     mkdir /etc

--- a/steps/jump/move_disk.sh
+++ b/steps/jump/move_disk.sh
@@ -4,7 +4,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-set -ex
+set -e
+# mount might fail if /etc doesn't exist because of fstab and mtab
+mkdir -p /dev /etc
+mount -t devtmpfs none /dev &> /junk || true # no /dev/null yet
+rm /junk &> /dev/null || true
 
 # Create partition if it doesn't exist
 if [ $(($(stat -c "%Lr" "/dev/${DISK}") % 8)) -eq 0 ]; then

--- a/steps/manifest
+++ b/steps/manifest
@@ -118,11 +118,10 @@ improve: clean_sources
 build: linux-4.9.10 ( BUILD_LINUX == True )
 jump: break ( INTERNAL_CI == pass1 )
 jump: linux ( CHROOT == False )
+jump: move_disk ( KERNEL_BOOTSTRAP == True )
 improve: finalize_fhs
 build: musl-1.2.4
 build: curl-8.5.0
-improve: populate_device_nodes
-jump: move_disk ( KERNEL_BOOTSTRAP == True )
 improve: get_network ( CHROOT == False )
 build: bash-5.2.15
 build: xz-5.4.1


### PR DESCRIPTION
With this, finalize_fhs.sh can be rerun as needed, e.g. when rebooting. Also, the preferred nameserver will persist after DHCP.

Thanks to devtmpfs, we no longer need to manage /dev once Linux is up.