### PR TITLE
Fix panic due to after.sh prematurely quitting on shutdown

### DIFF
--- a/steps/improve/after.sh
+++ b/steps/improve/after.sh
@@ -21,4 +21,5 @@ if [ "${CHROOT}" = False ]; then
     echo u > /proc/sysrq-trigger
     mount -o remount,ro /
     echo o > /proc/sysrq-trigger # power off
+    while true; do sleep 1; done
 fi


### PR DESCRIPTION
The sysrq shutdown trigger takes some time to fully shut down the system, during which init is expected to continue running. Since after.sh is the last step in our init, if it quits before shutdown is complete, Linux will panic with "Attempted to kill init".

Add an infinite loop after shutdown is issued via sysrq to prevent this.