### PR TITLE
Fix the default build script used by "build <package name>"

### DIFF
--- a/steps/helpers.sh
+++ b/steps/helpers.sh
@@ -113,11 +113,12 @@ bin_preseed() {
 # that can be overridden on per package basis in the build script.
 # build takes two arguments:
 # 1) name-version of the package
-# 2) optionally specify build script. Default is name-version.sh
+# 2) optionally specify build script. Default is pass$((revision+1)).sh
 # 3) optionally specify directory to cd into
 build() {
     pkg=$1
-    script_name=${2:-${pkg}.sh}
+    get_revision "${pkg}"
+    script_name=${2:-pass$((revision+1)).sh}
     dirname=${3:-${pkg}}
 
     # shellcheck disable=SC2015
@@ -176,7 +177,6 @@ build() {
     call $build_stage
 
     echo "${pkg}: creating package."
-    get_revision "${pkg}"
     cd "${DESTDIR}"
     src_pkg
 


### PR DESCRIPTION
Before the simplify refactor, the convention was to name the first or default build script "<package name>.sh". The refactor changed this default to "pass1.sh", with "pass2.sh" and so on used for subsequent passes. This wasn't an issue when building usig scripts generated by script-generator (which explicitly declares the build script to use), but broke running "build <package name>" without an explicit script name from the post-bootstrap bash prompt.

By deriving the script name from the current revision/pass number, this commit restores that functionality.

An unfortunate blemish is that we number build scripts from 1, but repo tarballs from 0 - it would be nice to standardize on a single indexing convention.