### PR TITLE
Fix typo in script-generator causing wrong traps in new Bash

### DIFF
--- a/seed/script-generator.c
+++ b/seed/script-generator.c
@@ -557,7 +557,7 @@ void generate(Directive *directives) {
 					 */
 					generate_preseed_jump(counter);
 				}
-				bash_build = 1;
+				bash_build += 1;
 				/* Create call to new script. */
 				output_call_script(out, "", int2str(counter, 10, 0), bash_build, 0);
 				fclose(out);


### PR DESCRIPTION
When renaming using_bash to bash_build, I accidentally removed the `+` sign from the assignment, causing `bash_build > 1` to never match, resulting in old-style Ctrl+D traps even in the new Bash.

This patch restores the intended `+=` behavior.