### PR TITLE
Improve pseudo-interactive prompts using the early bash

### DIFF
--- a/seed/script-generator.c
+++ b/seed/script-generator.c
@@ -451,8 +451,9 @@ FILE *start_script(int id, int bash_build) {
 			if (bash_build != 1) {
 				fputs("set -E\ntrap 'env PS1=\"[TRAP] \\w # \" bash -i' ERR\n", out);
 			} else {
-				fputs("set -E\ntrap 'bash -c '\"'\"'while true; do printf \""
-				"[TRAP - use Ctrl+D] $(pwd) # \"; $(cat); done'\"'\"'' ERR\n",
+				/* FIXME early bash has buggy ERR trap handling */
+				fputs("set -e\ntrap 'bash -c '\"'\"'while true; do printf \""
+				"[TRAP - use Ctrl+D] $(pwd) # \"; eval \"$(cat)\"; done'\"'\"'' EXIT\n",
 				out);
 			}
 		} else {

--- a/steps/improve/open_console.sh
+++ b/steps/improve/open_console.sh
@@ -7,5 +7,5 @@
 if bash --version | grep -q 'GPLv3'; then
     env - PATH=${PREFIX}/bin PS1="\w # " openvt -- bash -i
 else
-    bash -c 'while true; do printf "[early Bash - use Ctrl+D] $(pwd) # "; $(cat /dev/tty2); done' &> /dev/tty2 &
+    bash -c 'while true; do printf "[early Bash - use Ctrl+D] $(pwd) # "; eval "$(cat /dev/tty2)"; done' &> /dev/tty2 &
 fi


### PR DESCRIPTION
By wrapping $(cat) in an eval, redirections and other advanced syntax can now work in the early prompts.
Also, since "set -E" is broken is the early bash, fall back to using "set -e" and an EXIT trap, until we can upgrade to a bash version that already has working "set -E", or perhaps backport it to 2.05b.