### PR TITLE
 Use e820 memory map from BIOS, if available

### DIFF
--- a/steps/jump/fiwix.sh
+++ b/steps/jump/fiwix.sh
@@ -7,7 +7,11 @@
 set -ex
 
 # Build the ext2 image
-make_fiwix_initrd
+make_fiwix_initrd -s 1310720 /boot/fiwix.ext2
 
 # Boot Fiwix
-kexec-fiwix
+if match x${BARE_METAL} xTrue; then
+    kexec-fiwix /boot/fiwix -i /boot/fiwix.ext2 -c "fiwix console=/dev/tty1 root=/dev/ram0 initrd=fiwix.ext2 kexec_proto=linux kexec_size=262144 kexec_cmdline=\"init=/init consoleblank=0\""
+else
+    kexec-fiwix /boot/fiwix -i /boot/fiwix.ext2 -c "fiwix console=/dev/ttyS0 root=/dev/ram0 initrd=fiwix.ext2 kexec_proto=linux kexec_size=262144 kexec_cmdline=\"init=/init console=ttyS0\""
+fi

--- a/steps/jump/fiwix.sh
+++ b/steps/jump/fiwix.sh
@@ -11,7 +11,7 @@ make_fiwix_initrd -s 1310720 /boot/fiwix.ext2
 
 # Boot Fiwix
 if match x${BARE_METAL} xTrue; then
-    kexec-fiwix /boot/fiwix -i /boot/fiwix.ext2 -c "fiwix console=/dev/tty1 root=/dev/ram0 initrd=fiwix.ext2 kexec_proto=linux kexec_size=262144 kexec_cmdline=\"init=/init consoleblank=0\""
+    kexec-fiwix /boot/fiwix -i /boot/fiwix.ext2 -m /e820 -c "fiwix console=/dev/tty1 root=/dev/ram0 initrd=fiwix.ext2 kexec_proto=linux kexec_size=262144 kexec_cmdline=\"init=/init consoleblank=0\""
 else
-    kexec-fiwix /boot/fiwix -i /boot/fiwix.ext2 -c "fiwix console=/dev/ttyS0 root=/dev/ram0 initrd=fiwix.ext2 kexec_proto=linux kexec_size=262144 kexec_cmdline=\"init=/init console=ttyS0\""
+    kexec-fiwix /boot/fiwix -i /boot/fiwix.ext2 -m /e820 -c "fiwix console=/dev/ttyS0 root=/dev/ram0 initrd=fiwix.ext2 kexec_proto=linux kexec_size=262144 kexec_cmdline=\"init=/init console=ttyS0\""
 fi

--- a/steps/kexec-fiwix-1.0/kexec-fiwix-1.0.checksums
+++ b/steps/kexec-fiwix-1.0/kexec-fiwix-1.0.checksums
@@ -1,1 +1,1 @@
-d4f502384ab723ae4b3bf33e8024a93c71cba8481f8065182a8f21ffff0fbd6d  /usr/bin/kexec-fiwix
+70dc5c96cf3103ce199b7bf225a1dc04d4a25122af13f9840c6865d2c862a881  /usr/bin/kexec-fiwix

--- a/steps/lwext4-1.0.0-lb1/lwext4-1.0.0-lb1.checksums
+++ b/steps/lwext4-1.0.0-lb1/lwext4-1.0.0-lb1.checksums
@@ -1,1 +1,1 @@
-76bc5cca226d1244f1f648656959a955e8ff61fdca3d98d589a46be811628ba7  /usr/bin/make_fiwix_initrd
+5c750a976c8398092383783db26718002a67882bd8a7348a4d8f551cac02ee37  /usr/bin/make_fiwix_initrd


### PR DESCRIPTION
This extends make_fiwix_initrd and kexec-fiwix to support command line parameters, instead of hardcoding relevant values within the C sources. This way, it becomes possible to alter e.g. ramdisk size without affecting checksums.

While we're at it, also support loading a memory map from a file populated by builder-hex0 based on the BIOS E820 memory map.

Depends on https://github.com/ironmeld/builder-hex0/pull/12