### PR TITLE
Capture everything built before the repo system in a base tarball

### DIFF
--- a/rootfs.py
+++ b/rootfs.py
@@ -28,6 +28,8 @@ def create_configuration_file(args):
     """
     config_path = os.path.join('steps', 'bootstrap.cfg')
     with open(config_path, "w", encoding="utf_8") as config:
+        config.write(f"ARCH={args.arch}\n")
+        config.write(f"ARCH_DIR={stage0_arch_map.get(args.arch, args.arch)}\n")
         config.write(f"FORCE_TIMESTAMPS={args.force_timestamps}\n")
         config.write(f"CHROOT={args.chroot or args.bwrap}\n")
         config.write(f"UPDATE_CHECKSUMS={args.update_checksums}\n")

--- a/steps/bzip2-1.0.8/pass1.kaem
+++ b/steps/bzip2-1.0.8/pass1.kaem
@@ -12,12 +12,13 @@ checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
 mkdir build src
-cd build 
+cd build
 
 # Extract
 cp ${DISTFILES}/${pkg}.tar.xz ../src/
 unxz --file ../src/${pkg}.tar.xz --output ../src/${pkg}.tar
 tar xf ../src/${pkg}.tar
+rm -r ../src
 cd ${pkg}
 
 # Patch

--- a/steps/coreutils-5.0/pass1.kaem
+++ b/steps/coreutils-5.0/pass1.kaem
@@ -20,6 +20,7 @@ cd build
 cp ${DISTFILES}/${pkg}.tar.bz2 ../src/
 bunzip2 -f ../src/${pkg}.tar.bz2
 tar xf ../src/${pkg}.tar
+rm -r ../src
 cd ${pkg}
 cp ../../mk/main.mk Makefile
 

--- a/steps/fiwix-1.5.0-lb1/pass1.kaem
+++ b/steps/fiwix-1.5.0-lb1/pass1.kaem
@@ -9,13 +9,10 @@ checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
 # Extract
-mkdir build src
-cd src
-ungz --file ${DISTFILES}/${pkg}.tar.gz --output ${pkg}.tar
-cd ..
-
+mkdir build
 cd build
-untar --file ../src/${pkg}.tar
+ungz --file ${DISTFILES}/${pkg}.tar.gz --output ${pkg}.tar
+untar --file ${pkg}.tar
 cd ${pkg}
 
 cp ../../files/custom_config.h include/fiwix

--- a/steps/gzip-1.2.4/pass1.kaem
+++ b/steps/gzip-1.2.4/pass1.kaem
@@ -12,13 +12,13 @@ set -ex
 checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
-mkdir build src
+mkdir build
 cd build
 
 # Extract
-ungz --file ${DISTFILES}/${pkg}.tar.gz --output ../src/${pkg}.tar
-untar --file ../src/${pkg}.tar
-rm ../src/${pkg}.tar
+ungz --file ${DISTFILES}/${pkg}.tar.gz --output ${pkg}.tar
+untar --file ${pkg}.tar
+rm ${pkg}.tar
 cd ${pkg}
 
 # Prepare

--- a/steps/improve/clean_artifacts.sh
+++ b/steps/improve/clean_artifacts.sh
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024 Gábor Stefanik <netrolller.3d@gmail.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Delete build artifacts to free up space for Linux kernel build
+
+for pkg in $(ls "${SRCDIR}"); do
+    if [ -d "${SRCDIR}/${pkg}/build" ]; then
+        rm -rf "${SRCDIR}/${pkg}/build"
+    fi
+done
+
+rm -rf "/${ARCH_DIR}/artifact"

--- a/steps/improve/setup_repo.sh
+++ b/steps/improve/setup_repo.sh
@@ -5,3 +5,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 mkdir -p /external/repo
+
+tar -cf - --exclude='/external/repo/*' --exclude='/external/repo-preseeded/*' --exclude='/external/distfiles/*' --exclude='/dev/*' --exclude='/proc/*' --exclude='/sys/*' --exclude='/tmp/*' / | bzip2 --best > /external/repo/base.tar.bz2

--- a/steps/lwext4-1.0.0-lb1/pass1.kaem
+++ b/steps/lwext4-1.0.0-lb1/pass1.kaem
@@ -4,13 +4,10 @@
 
 set -ex
 
-mkdir build src
-cd src
-ungz --file ${DISTFILES}/${pkg}.tar.gz --output ${pkg}.tar
-cd ..
-
+mkdir build
 cd build
-untar --file ../src/${pkg}.tar
+ungz --file ${DISTFILES}/${pkg}.tar.gz --output ${pkg}.tar
+untar --file ${pkg}.tar
 cd ${pkg}
 
 mkdir -p build_generic/include/generated

--- a/steps/make-3.82/pass1.kaem
+++ b/steps/make-3.82/pass1.kaem
@@ -10,13 +10,13 @@ set -ex
 checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
-mkdir build src
+mkdir build
 cd build 
 
 # Extract
-unbz2 --file ${DISTFILES}/${pkg}.tar.bz2 --output ../src/${pkg}.tar
-untar --file ../src/${pkg}.tar
-rm ../src/${pkg}.tar
+unbz2 --file ${DISTFILES}/${pkg}.tar.bz2 --output ${pkg}.tar
+untar --file ${pkg}.tar
+rm ${pkg}.tar
 cd ${pkg}
 
 # Create .h files

--- a/steps/manifest
+++ b/steps/manifest
@@ -123,6 +123,7 @@ define: BUILD_LINUX = ( CHROOT == False || BUILD_KERNELS == True )
 build: kexec-linux-1.0.0 ( BUILD_LINUX == True )
 build: kexec-tools-2.0.22 ( BUILD_LINUX == True )
 improve: clean_sources
+improve: clean_artifacts
 build: linux-4.9.10 ( BUILD_LINUX == True )
 jump: break ( INTERNAL_CI == pass1 )
 improve: populate_device_nodes

--- a/steps/mes-0.25/pass1.kaem
+++ b/steps/mes-0.25/pass1.kaem
@@ -32,19 +32,16 @@ checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
 # Unpack
-mkdir src build
-cd src
+mkdir build
+cd build
 ungz --file ${DISTFILES}/${NYACC_PKG}.tar.gz --output ${NYACC_PKG}.tar
 ungz --file ${DISTFILES}/${MES_PKG}.tar.gz --output ${MES_PKG}.tar
-cd ..
-
-cd build
-untar --file ../src/${NYACC_PKG}.tar
-untar --non-strict --file ../src/${MES_PKG}.tar # ignore symlinks
+untar --file ${NYACC_PKG}.tar
+untar --non-strict --file ${MES_PKG}.tar # ignore symlinks
 mes_run=${MES_PREFIX}/kaem.run
 replace --file ${mes_run} --output ${mes_run} --match-on 0x1000000 --replace-with 0x8048000
 
-rm ../src/${NYACC_PKG}.tar ../src/${MES_PKG}.tar
+rm ${NYACC_PKG}.tar ${MES_PKG}.tar
 
 cp ../files/config.h ${MES_PREFIX}/include/mes
 

--- a/steps/patch-2.5.9/pass1.kaem
+++ b/steps/patch-2.5.9/pass1.kaem
@@ -10,13 +10,13 @@ set -ex
 checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
-mkdir build src
+mkdir build
 cd build
 
 # Extract
-cp ${DISTFILES}/${pkg}.tar.gz ../src/
-ungz --file ../src/${pkg}.tar.gz --output ../src/${pkg}.tar
-untar --file ../src/${pkg}.tar
+ungz --file ${DISTFILES}/${pkg}.tar.gz --output ${pkg}.tar
+untar --file ${pkg}.tar
+rm ${pkg}.tar
 cd ${pkg}
 cp ../../mk/main.mk Makefile
 

--- a/steps/sed-4.0.9/pass1.kaem
+++ b/steps/sed-4.0.9/pass1.kaem
@@ -19,6 +19,7 @@ cd build
 cp ${DISTFILES}/${pkg}.tar.gz ../src/
 gzip -d -f ../src/${pkg}.tar.gz
 tar xf ../src/${pkg}.tar
+rm -r ../src
 cd ${pkg}
 cp ../../mk/main.mk Makefile
 

--- a/steps/tar-1.12/pass1.kaem
+++ b/steps/tar-1.12/pass1.kaem
@@ -19,7 +19,7 @@ cd build
 cp ${DISTFILES}/${pkg}.tar.gz ../src/
 gzip -d -f ../src/${pkg}.tar.gz
 untar --file ../src/${pkg}.tar
-rm ../src/${pkg}.tar
+rm -r ../src
 
 cd ${pkg}
 

--- a/steps/tcc-0.9.26/pass1.kaem
+++ b/steps/tcc-0.9.26/pass1.kaem
@@ -22,21 +22,18 @@ checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
 # Unpack
-mkdir src build
-
-cd src
-ungz --file ${DISTFILES}/${TCC_TAR}.tar.gz --output ${TCC_TAR}.tar
-ungz --file ${DISTFILES}/${MES_PKG}.tar.gz --output ${MES_PKG}.tar
-cd ..
+mkdir build
 
 cd build
-untar --non-strict --file ../src/${TCC_TAR}.tar
+ungz --file ${DISTFILES}/${TCC_TAR}.tar.gz --output ${TCC_TAR}.tar
+ungz --file ${DISTFILES}/${MES_PKG}.tar.gz --output ${MES_PKG}.tar
+untar --non-strict --file ${TCC_TAR}.tar
 simple-patch ${TCC_PKG}/tcctools.c \
     ../simple-patches/remove-fileopen.before ../simple-patches/remove-fileopen.after
 simple-patch ${TCC_PKG}/tcctools.c \
     ../simple-patches/addback-fileopen.before ../simple-patches/addback-fileopen.after
 
-untar --non-strict --file ../src/${MES_PKG}.tar
+untar --non-strict --file ${MES_PKG}.tar
 
 # Create config.h
 catm ${MES_PKG}/include/mes/config.h

--- a/steps/tcc-0.9.27/pass1.kaem
+++ b/steps/tcc-0.9.27/pass1.kaem
@@ -12,14 +12,11 @@ checksum-transcriber sources
 sha256sum -c sources.SHA256SUM
 
 # Extract
-mkdir build src
-cd src
+mkdir build
+cd build
 unbz2 --file ${DISTFILES}/${pkg}.tar.bz2 --output ${pkg}.tar
 ungz --file ${DISTFILES}/${MES_PKG}.tar.gz --output ${MES_PKG}.tar
-cd ..
-
-cd build
-untar --file ../src/${pkg}.tar
+untar --file ${pkg}.tar
 simple-patch tcc-0.9.27/tcctools.c \
     ../simple-patches/remove-fileopen.before ../simple-patches/remove-fileopen.after
 simple-patch tcc-0.9.27/tcctools.c \
@@ -29,7 +26,7 @@ simple-patch tcc-0.9.27/tccelf.c \
 # Fix SIGSEGV while building lwext4
 simple-patch tcc-0.9.27/tccelf.c \
     ../simple-patches/check-reloc-null.before ../simple-patches/check-reloc-null.after
-untar --non-strict --file ../src/${MES_PKG}.tar
+untar --non-strict --file ${MES_PKG}.tar
 cd ${pkg}
 
 # Create config.h


### PR DESCRIPTION
Parts built before bash and the repo system are available aren't stored in a clean repository tarball, so if any early file is
overwritten, it's lost. Fix this by creating a base.tar.bz2 right after the repo is set up, to hold reference copies of early files.

This tarball isn't checksummed, since it varies considerably with bootstrap options, but the binaries inside are protected by their
own checksums.

Depends on #437 