### PR TITLE
Allow grub to autodetect screen resolution

### DIFF
--- a/steps/improve/make_bootable.sh
+++ b/steps/improve/make_bootable.sh
@@ -27,6 +27,7 @@ set default=0
 menuentry 'Linux live-bootstrap (4.9.10)' {
     insmod part_msdos
     set root='$(grub-probe -d /dev/${DISK} -t bios_hints | sed -e 's/ //g')'
+    set gfxpayload=auto
     linux /boot/linux-4.9.10 root=/dev/${DISK} rw $(cat /proc/cmdline)
 }
 EOF


### PR DESCRIPTION
With this, systems without a supported non-vesa FB driver in Linux (such as Intel integrated graphics) get full resolution after reboot.