### PR TITLE
Add extension mechanism to execute .sh files dropped in /steps/after

### DIFF
--- a/steps/improve/after.sh
+++ b/steps/improve/after.sh
@@ -9,6 +9,10 @@
 . /steps/bootstrap.cfg
 . /steps/env
 
+if [ -d /steps/after ]; then
+    find /steps/after -maxdepth 1 -name '*.sh' -exec bash {} \;
+fi
+
 if [ "${INTERACTIVE}" = True ]; then
     env - PATH=${PREFIX}/bin PS1="\w # " setsid openvt -fec1 -- bash -i
 fi


### PR DESCRIPTION
These are executed at the end of the bootstrap, if /steps/after exists. In interactive mode, they run before the interactive prompt is displayed.