### PR TITLE
Fix early-preseed (and environment variables generally)

### DIFF
--- a/steps/heirloom-devtools-070527/pass1.sh
+++ b/steps/heirloom-devtools-070527/pass1.sh
@@ -8,7 +8,7 @@
 
 src_compile() {
     cd lex
-    make -f Makefile.mk CC=tcc AR=tcc\ -ar LDFLAGS=-static RANLIB=true
+    make -f Makefile.mk CC=tcc AR="tcc -ar" LDFLAGS=-static RANLIB=true LIBDIR="${LIBDIR}"
     cd ..
 }
 
@@ -18,4 +18,3 @@ src_install() {
     install lex/libl.a "${DESTDIR}${LIBDIR}"
     install -m 644 lex/ncform "${DESTDIR}${LIBDIR}/lex"
 }
-

--- a/steps/improve/update_env.sh
+++ b/steps/improve/update_env.sh
@@ -21,4 +21,15 @@ export SHELL=/usr/bin/bash
 DESTDIR=/tmp/destdir
 EOF
 
+# The following values are set up in the kaem environment.
+# As these are then passed through to the bash shell, they are considered
+# automatically exported variables. We don't want them exported.
+unset PREFIX
+unset BINDIR
+unset LIBDIR
+unset INCDIR
+unset SRCDIR
+unset TMPDIR
+unset DISTFILES
+
 . /steps/env


### PR DESCRIPTION
There is currently a small environmental discrepancy between `--early-preseed` mode and normal mode which causes a build failure when `--early-preseed` is used.
Namely, bash reads any environment variables that are _already_ in the the environment. In `--early-preseed` mode there are none of these, whereas there are a number when bash is called from normal mode as a result of kaem setting those environment variables.
This causes variables such as `LIBDIR` to be `export`ed by default in kaem mode but not in `--early-preseed` mode. We can work around this by unsetting them and resetting them in `update_env.sh`.