### PR TITLE
Band-aid fix for #472 - get openssl from archive.org

### DIFF
--- a/steps/openssl-3.0.13/sources
+++ b/steps/openssl-3.0.13/sources
@@ -1,2 +1,1 @@
-http://ftp.openssl.org/source/openssl-3.0.13.tar.gz 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
-http://ftp.openssl.org/source/old/3.0/openssl-3.0.13.tar.gz 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
+http://web.archive.org/web/20240213065706im_/https://www.openssl.org/source/openssl-3.0.13.tar.gz 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313


### PR DESCRIPTION
While this works for now, it's not a sustainable solution. Supporting a simpler SSL library (small enough to bundle into srcfs) such as BearSSL or WolfSSL in the first build of curl would be preferable.