### PR TITLE
Abort execution on non-0 exit status from "after" scripts

### DIFF
--- a/steps/improve/after.sh
+++ b/steps/improve/after.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # SPDX-FileCopyrightText: 2024 Gábor Stefanik <netrolller.3d@gmail.com>
+# SPDX-FileCopyrightText: 2025 Dor Askayo <dor.askayo@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -10,7 +11,10 @@
 . /steps/env
 
 if [ -d /steps/after ]; then
-    find /steps/after -maxdepth 1 -name '*.sh' -exec bash {} \;
+    after_scripts=$(find /steps/after -maxdepth 1 -type f -name '*.sh' -printf '%f\t%p\n' | sort -k1 -n | cut -f2)
+    for script in $after_scripts; do
+        bash "$script"
+    done
 fi
 
 if [ "${INTERACTIVE}" = True ]; then


### PR DESCRIPTION
From the commit message:

    Failures in "after" scripts do not currently result in bootstrap
    failures since "find" ignores the exit code of commands that it
    executes.
    
    There are no simple options in "find" to both propagate non-0 exit
    statuses of executed commands and also abort its command execution
    sequence in such an event. As such, use "find" only for listing
    script names and otherwise use a simple loop to execute them.
    
    While at it, execute scripts in numerical order according to their
    basename. This gives consumers control over the execution order of
    their scripts. For example, 50-sign.sh will be executed before
    51-upload.sh.

This is needed to avoid bootstraps registering as successful in CI even though there were failures in "after" scripts. I ran into this issue when updating freedesktop-sdk's bootstrap to be based on a newer version of live-bootstrap (see: [freedesktop-sdk-binary-seed!102](https://gitlab.com/freedesktop-sdk/freedesktop-sdk-binary-seed/-/merge_requests/102))