### PR TITLE
Make download-distfiles.sh read from steps/manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 target/
 kernel
 distfiles/
+mirrorstate/
 __pycache__
 steps/bootstrap.cfg


### PR DESCRIPTION
This brings the shell script closer to what get_packages() at lib/generator.py does.

It allows for downloading only what is specified in the manifest.

---

This is useful for partial builds or custom manifests. I also removed some bashisms (arrays, `[[`) to improve portability to shells other than bash.