### PR TITLE
Update sources for libatomic_ops

### DIFF
--- a/steps/libatomic_ops-7.6.10/sources
+++ b/steps/libatomic_ops-7.6.10/sources
@@ -1,1 +1,1 @@
-https://github.com/ivmai/libatomic_ops/releases/download/v7.6.10/libatomic_ops-7.6.10.tar.gz 587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af
+https://www.hboehm.info/gc/gc_source/libatomic_ops-7.6.10.tar.gz 587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af


### PR DESCRIPTION
I noticed this while working on #525.

The previous download source became unavailable, I was able to find in their README a link for their website which contains direct download links.

Maybe it should be a git:// source instead? Let me know if that would be preferred and I'll change it!