### PR TITLE
Allow --qemu and file:// --mirrors to be used together

### DIFF
--- a/rootfs.py
+++ b/rootfs.py
@@ -41,6 +41,7 @@ def create_configuration_file(args):
         config.write(f"FINAL_JOBS={args.cores}\n")
         config.write(f"INTERNAL_CI={args.internal_ci or False}\n")
         config.write(f"INTERACTIVE={args.interactive}\n")
+        config.write(f"QEMU={args.qemu}\n")
         config.write(f"BARE_METAL={args.bare_metal or (args.qemu and args.interactive)}\n")
         if (args.bare_metal or args.qemu) and not args.kernel:
             if args.repo or args.external_sources:

--- a/steps/helpers.sh
+++ b/steps/helpers.sh
@@ -283,6 +283,10 @@ download_source_line() {
     fname="${fname:-$(basename "${upstream_url}")}"
     if ! [ -e "${fname}" ]; then
         for mirror in $(randomize "${MIRRORS}"); do
+            # In qemu SimpleMirror is not running on the guest os, use qemu IP
+            case "${QEMU}-${mirror}" in 'True-http://127.0.0.1'*)
+                mirror="http://10.0.2.2${mirror#'http://127.0.0.1'}"
+            esac
             mirror_url="${mirror}/${fname}"
             echo "${mirror_url}"
             curl --fail --retry 3 --location "${mirror_url}" --output "${fname}" || true && break


### PR DESCRIPTION
When using `file://` mirrors, rootfs.py will spawn a local HTTP server at 127.0.0.1.

In combination with `--qemu`, this poses a problem: downloads on the host machine will work, but downloads on the guest machine will not reach the local server.

This commit introduces a change to rewrite the address to 10.0.2.2 inside the guest, only when QEMU=True is set in the configuration, allowing this combination to build past the get_network improvement step.