### PR TITLE
fix validate mirrors function not respecting the external_sources argument

### DIFF
--- a/rootfs.py
+++ b/rootfs.py
@@ -179,7 +179,7 @@ def main():
         args.swap = 0
 
     # Validate mirrors
-    if not args.mirrors:
+    if not args.mirrors and not args.external_sources:
         raise ValueError("At least one mirror must be provided.")
 
     # Set constant umask


### PR DESCRIPTION
This change adds a check to see if external sources was not set before running the validate mirrors function. (fix for Issue 539)