### PR TITLE
Fix depcomp being deleted in GCC

### DIFF
--- a/steps/gcc-10.5.0/pass1.sh
+++ b/steps/gcc-10.5.0/pass1.sh
@@ -101,13 +101,12 @@ src_prepare() {
     
     # Regenerate autotools
     # configure
+    touch depcomp
     find . -name configure | sed 's:/configure::' | while read d; do
         pushd "${d}"
         AUTOMAKE=automake-1.15 ACLOCAL=aclocal-1.15 autoreconf-2.69 -fiv
         popd
     done
-    # Because GCC is stupid, copy depcomp back in
-    cp "${PREFIX}/share/automake-1.15/depcomp" .
     # Makefile.in only
     BACK="${PWD}"
     find . -type d \

--- a/steps/gcc-15.2.0/pass1.sh
+++ b/steps/gcc-15.2.0/pass1.sh
@@ -138,6 +138,7 @@ src_prepare() {
 
     # Regenerate autotools
     # configure
+    touch depcomp
     find . -name configure | sed 's:/configure::' | while read d; do
         pushd "${d}"
         AUTOMAKE=automake-1.15 ACLOCAL=aclocal-1.15 autoreconf-2.69 -fiv


### PR DESCRIPTION
On my system, (usually) depcomp is deleted during autoreconf. The reasons for this are very unclear but appear to be timestamp related. This seems to fix it.