### PR TITLE
Fix depcomp being deleted in GCC: 2nd attempt

### DIFF
--- a/steps/gcc-10.5.0/pass1.sh
+++ b/steps/gcc-10.5.0/pass1.sh
@@ -101,12 +101,13 @@ src_prepare() {
     
     # Regenerate autotools
     # configure
-    touch depcomp
     find . -name configure | sed 's:/configure::' | while read d; do
         pushd "${d}"
         AUTOMAKE=automake-1.15 ACLOCAL=aclocal-1.15 autoreconf-2.69 -fiv
         popd
     done
+    # Because GCC is stupid, copy depcomp back in
+    cp "${PREFIX}/share/automake-1.15/depcomp" .
     # Makefile.in only
     BACK="${PWD}"
     find . -type d \

--- a/steps/gcc-15.2.0/pass1.sh
+++ b/steps/gcc-15.2.0/pass1.sh
@@ -138,12 +138,13 @@ src_prepare() {
 
     # Regenerate autotools
     # configure
-    touch depcomp
     find . -name configure | sed 's:/configure::' | while read d; do
         pushd "${d}"
         AUTOMAKE=automake-1.15 ACLOCAL=aclocal-1.15 autoreconf-2.69 -fiv
         popd
     done
+    # Because GCC is stupid, copy depcomp back in
+    cp "${PREFIX}/share/automake-1.15/depcomp" .
     # A odd script
     pushd gcc/m2/gm2-libs
     autoconf-2.69 -f config-host.in > config-host


### PR DESCRIPTION
The first attempt doesn't always work. Revert to the previous more ugly fix.