### PR TITLE
Better git repo handling

### DIFF
--- a/lib/generator.py
+++ b/lib/generator.py
@@ -366,16 +366,16 @@ this script the next time")
                         for source in sources.readlines():
                             source = source.strip().split(" ")
 
-                            if source[0].startswith("git://"):
-                                source = source[1:]
+                            if source[0] == "g" or source[0] == "git":
+                                source[1:] = source[2:]
 
-                            if len(source) > 2:
-                                file_name = source[2]
+                            if len(source) > 3:
+                                file_name = source[3]
                             else:
                                 # Automatically determine file name based on URL.
-                                file_name = os.path.basename(source[0])
+                                file_name = os.path.basename(source[1])
 
-                            entry = (source[1], directory, source[0], file_name)
+                            entry = (source[2], directory, source[1], file_name)
                             if entry not in entries:
                                 entries.append(entry)
 

--- a/steps/autoconf-2.52/sources
+++ b/steps/autoconf-2.52/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.52.tar.bz2 4681bcbb9c9298c506f6405a7deb62c54fc3b339d3239a8f36a5df83daaec94f
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.52.tar.bz2 4681bcbb9c9298c506f6405a7deb62c54fc3b339d3239a8f36a5df83daaec94f

--- a/steps/autoconf-2.53/sources
+++ b/steps/autoconf-2.53/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.53.tar.bz2 6b217a064c6d06603d50a3ad05129aef9435367810c10894210b8dad965d2306
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.53.tar.bz2 6b217a064c6d06603d50a3ad05129aef9435367810c10894210b8dad965d2306

--- a/steps/autoconf-2.54/sources
+++ b/steps/autoconf-2.54/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.54.tar.bz2 a74aea954f36c7beeb6cc47b96a408c3e04e7ad635f614e65250dbcd8ec0bd28
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.54.tar.bz2 a74aea954f36c7beeb6cc47b96a408c3e04e7ad635f614e65250dbcd8ec0bd28

--- a/steps/autoconf-2.55/sources
+++ b/steps/autoconf-2.55/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.55.tar.bz2 f757158a04889b265203eecd8ca92568e2a67c3b9062fa6bff7a0a6efd2244ac
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.55.tar.bz2 f757158a04889b265203eecd8ca92568e2a67c3b9062fa6bff7a0a6efd2244ac

--- a/steps/autoconf-2.57/sources
+++ b/steps/autoconf-2.57/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.57.tar.bz2 e1035aa2c21fae2a934d1ab56c774ce9d22717881dab8a1a5b16d294fb793489
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.57.tar.bz2 e1035aa2c21fae2a934d1ab56c774ce9d22717881dab8a1a5b16d294fb793489

--- a/steps/autoconf-2.59/sources
+++ b/steps/autoconf-2.59/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.59.tar.bz2 f0cde70a8f135098a6a3e85869f2e1cc3f141beea766fa3d6636e086cd8b90a7
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.59.tar.bz2 f0cde70a8f135098a6a3e85869f2e1cc3f141beea766fa3d6636e086cd8b90a7

--- a/steps/autoconf-2.61/sources
+++ b/steps/autoconf-2.61/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.61.tar.bz2 93a2ceab963618b021db153f0c881a2de82455c1dc7422be436fcd5c554085a1
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.61.tar.bz2 93a2ceab963618b021db153f0c881a2de82455c1dc7422be436fcd5c554085a1

--- a/steps/autoconf-2.64/sources
+++ b/steps/autoconf-2.64/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.64.tar.xz 32d977213320b8ae76c71175305301197f2b0e04e72d70694bc3d3e2ae6c7248
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.64.tar.xz 32d977213320b8ae76c71175305301197f2b0e04e72d70694bc3d3e2ae6c7248

--- a/steps/autoconf-2.69/sources
+++ b/steps/autoconf-2.69/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.69.tar.xz 64ebcec9f8ac5b2487125a86a7760d2591ac9e1d3dbd59489633f9de62a57684
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.69.tar.xz 64ebcec9f8ac5b2487125a86a7760d2591ac9e1d3dbd59489633f9de62a57684

--- a/steps/autoconf-2.71/sources
+++ b/steps/autoconf-2.71/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/autoconf/autoconf-2.71.tar.xz f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4
+f https://mirrors.kernel.org/gnu/autoconf/autoconf-2.71.tar.xz f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4

--- a/steps/autoconf-archive-2021.02.19/sources
+++ b/steps/autoconf-archive-2021.02.19/sources
@@ -1,1 +1,1 @@
-http://mirrors.kernel.org/gnu/autoconf-archive/autoconf-archive-2021.02.19.tar.xz e8a6eb9d28ddcba8ffef3fa211653239e9bf239aba6a01a6b7cfc7ceaec69cbd
+f http://mirrors.kernel.org/gnu/autoconf-archive/autoconf-archive-2021.02.19.tar.xz e8a6eb9d28ddcba8ffef3fa211653239e9bf239aba6a01a6b7cfc7ceaec69cbd

--- a/steps/autogen-5.18.16/sources
+++ b/steps/autogen-5.18.16/sources
@@ -1,4 +1,4 @@
-git://github.com/schierlm/gnu-autogen-bootstrapping~autogen-5.18.16-v1.0.1 https://github.com/schierlm/gnu-autogen-bootstrapping/archive/refs/tags/autogen-5.18.16-v1.0.1.tar.gz 953ba180b18acff188a0a8700770c7cf2fc97e1683c7b9699a5a748b542ccdd5
-https://mirrors.kernel.org/gnu/autogen/rel5.18.16/autogen-5.18.16.tar.xz f8a13466b48faa3ba99fe17a069e71c9ab006d9b1cfabe699f8c60a47d5bb49a
-git://git.savannah.gnu.org/autogen.git~v5.18.16 https://git.savannah.gnu.org/cgit/autogen.git/snapshot/autogen-5.18.16.tar.gz 0c04ab2f7ce13c4a1c06c4abc7dfe75312aad89b8b0a1068e5e563787eb56632
-git://git.savannah.gnu.org/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz
+g git://github.com/schierlm/gnu-autogen-bootstrapping~autogen-5.18.16-v1.0.1 https://github.com/schierlm/gnu-autogen-bootstrapping/archive/refs/tags/autogen-5.18.16-v1.0.1.tar.gz 953ba180b18acff188a0a8700770c7cf2fc97e1683c7b9699a5a748b542ccdd5
+f https://mirrors.kernel.org/gnu/autogen/rel5.18.16/autogen-5.18.16.tar.xz f8a13466b48faa3ba99fe17a069e71c9ab006d9b1cfabe699f8c60a47d5bb49a
+g git://git.savannah.gnu.org/autogen.git~v5.18.16 https://git.savannah.gnu.org/cgit/autogen.git/snapshot/autogen-5.18.16.tar.gz 0c04ab2f7ce13c4a1c06c4abc7dfe75312aad89b8b0a1068e5e563787eb56632
+g git://git.savannah.gnu.org/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz

--- a/steps/autogen-5.18.16/sources
+++ b/steps/autogen-5.18.16/sources
@@ -1,4 +1,4 @@
-g git://github.com/schierlm/gnu-autogen-bootstrapping~autogen-5.18.16-v1.0.1 https://github.com/schierlm/gnu-autogen-bootstrapping/archive/refs/tags/autogen-5.18.16-v1.0.1.tar.gz 953ba180b18acff188a0a8700770c7cf2fc97e1683c7b9699a5a748b542ccdd5
+g https://github.com/schierlm/gnu-autogen-bootstrapping~autogen-5.18.16-v1.0.1 https://github.com/schierlm/gnu-autogen-bootstrapping/archive/refs/tags/autogen-5.18.16-v1.0.1.tar.gz 953ba180b18acff188a0a8700770c7cf2fc97e1683c7b9699a5a748b542ccdd5
 f https://mirrors.kernel.org/gnu/autogen/rel5.18.16/autogen-5.18.16.tar.xz f8a13466b48faa3ba99fe17a069e71c9ab006d9b1cfabe699f8c60a47d5bb49a
-g git://git.savannah.gnu.org/autogen.git~v5.18.16 https://git.savannah.gnu.org/cgit/autogen.git/snapshot/autogen-5.18.16.tar.gz 0c04ab2f7ce13c4a1c06c4abc7dfe75312aad89b8b0a1068e5e563787eb56632
-g git://git.savannah.gnu.org/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz
+g https://https.git.savannah.gnu.org/git/autogen.git~v5.18.16 https://git.savannah.gnu.org/cgit/autogen.git/snapshot/autogen-5.18.16.tar.gz 0c04ab2f7ce13c4a1c06c4abc7dfe75312aad89b8b0a1068e5e563787eb56632
+g https://https.git.savannah.gnu.org/git/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz

--- a/steps/automake-1.10.3/sources
+++ b/steps/automake-1.10.3/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.10.3.tar.bz2 e98ab43bb839c31696a4202e5b6ff388b391659ef2387cf9365019fad17e1adc
+f https://mirrors.kernel.org/gnu/automake/automake-1.10.3.tar.bz2 e98ab43bb839c31696a4202e5b6ff388b391659ef2387cf9365019fad17e1adc

--- a/steps/automake-1.11.2/sources
+++ b/steps/automake-1.11.2/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.11.2.tar.bz2 4f46d1f9380c8a3506280750f630e9fc915cb1a435b724be56b499d016368718
+f https://mirrors.kernel.org/gnu/automake/automake-1.11.2.tar.bz2 4f46d1f9380c8a3506280750f630e9fc915cb1a435b724be56b499d016368718

--- a/steps/automake-1.15.1/sources
+++ b/steps/automake-1.15.1/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.15.1.tar.xz af6ba39142220687c500f79b4aa2f181d9b24e4f8d8ec497cea4ba26c64bedaf
+f https://mirrors.kernel.org/gnu/automake/automake-1.15.1.tar.xz af6ba39142220687c500f79b4aa2f181d9b24e4f8d8ec497cea4ba26c64bedaf

--- a/steps/automake-1.16.3/sources
+++ b/steps/automake-1.16.3/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.16.3.tar.xz ff2bf7656c4d1c6fdda3b8bebb21f09153a736bcba169aaf65eab25fa113bf3a
+f https://mirrors.kernel.org/gnu/automake/automake-1.16.3.tar.xz ff2bf7656c4d1c6fdda3b8bebb21f09153a736bcba169aaf65eab25fa113bf3a

--- a/steps/automake-1.6.3/sources
+++ b/steps/automake-1.6.3/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.6.3.tar.bz2 0dbafacaf21e135cab35d357a14bdcd981d2f2d00e1387801be8091a31b7bb81
+f https://mirrors.kernel.org/gnu/automake/automake-1.6.3.tar.bz2 0dbafacaf21e135cab35d357a14bdcd981d2f2d00e1387801be8091a31b7bb81

--- a/steps/automake-1.7.8/sources
+++ b/steps/automake-1.7.8/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.7.8.tar.bz2 2dddc3b51506e702647ccc6757e15c05323fa67245d2d53e81ed36a832f9be42
+f https://mirrors.kernel.org/gnu/automake/automake-1.7.8.tar.bz2 2dddc3b51506e702647ccc6757e15c05323fa67245d2d53e81ed36a832f9be42

--- a/steps/automake-1.7/sources
+++ b/steps/automake-1.7/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.7.tar.bz2 6633ee1202375e3c8798a92e1b7f46894f78d541aeea7f49654503fdc0b28835
+f https://mirrors.kernel.org/gnu/automake/automake-1.7.tar.bz2 6633ee1202375e3c8798a92e1b7f46894f78d541aeea7f49654503fdc0b28835

--- a/steps/automake-1.8.5/sources
+++ b/steps/automake-1.8.5/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.8.5.tar.bz2 84c93aaa3c3651a9e7474b721b0e6788318592509e7de604bafe4ea8049dc410
+f https://mirrors.kernel.org/gnu/automake/automake-1.8.5.tar.bz2 84c93aaa3c3651a9e7474b721b0e6788318592509e7de604bafe4ea8049dc410

--- a/steps/automake-1.9.6/sources
+++ b/steps/automake-1.9.6/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/automake/automake-1.9.6.tar.bz2 8eccaa98e1863d10e4a5f861d8e2ec349a23e88cb12ad10f6b6f79022ad2bb8d
+f https://mirrors.kernel.org/gnu/automake/automake-1.9.6.tar.bz2 8eccaa98e1863d10e4a5f861d8e2ec349a23e88cb12ad10f6b6f79022ad2bb8d

--- a/steps/bash-2.05b/sources
+++ b/steps/bash-2.05b/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/bash/bash-2.05b.tar.gz ba03d412998cc54bd0b0f2d6c32100967d3137098affdc2d32e6e7c11b163fe4
+f https://mirrors.kernel.org/gnu/bash/bash-2.05b.tar.gz ba03d412998cc54bd0b0f2d6c32100967d3137098affdc2d32e6e7c11b163fe4

--- a/steps/bash-5.2.15/sources
+++ b/steps/bash-5.2.15/sources
@@ -1,1 +1,1 @@
-http://mirrors.kernel.org/gnu/bash/bash-5.2.15.tar.gz 13720965b5f4fc3a0d4b61dd37e7565c741da9a5be24edc2ae00182fc1b3588c
+f http://mirrors.kernel.org/gnu/bash/bash-5.2.15.tar.gz 13720965b5f4fc3a0d4b61dd37e7565c741da9a5be24edc2ae00182fc1b3588c

--- a/steps/bc-1.08.1/sources
+++ b/steps/bc-1.08.1/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/bc/bc-1.08.1.tar.xz 515430115b3334c636317503460a0950dff79940aa3259ce2c1aa67c2881d023 
+f https://mirrors.kernel.org/gnu/bc/bc-1.08.1.tar.xz 515430115b3334c636317503460a0950dff79940aa3259ce2c1aa67c2881d023 

--- a/steps/binutils-2.30/sources
+++ b/steps/binutils-2.30/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/binutils/binutils-2.30.tar.xz 6e46b8aeae2f727a36f0bd9505e405768a72218f1796f0d09757d45209871ae6
+f https://mirrors.kernel.org/gnu/binutils/binutils-2.30.tar.xz 6e46b8aeae2f727a36f0bd9505e405768a72218f1796f0d09757d45209871ae6

--- a/steps/binutils-2.41/sources
+++ b/steps/binutils-2.41/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/binutils/binutils-2.41.tar.xz ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450
+f https://mirrors.kernel.org/gnu/binutils/binutils-2.41.tar.xz ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450

--- a/steps/bison-2.3/sources
+++ b/steps/bison-2.3/sources
@@ -1,2 +1,2 @@
 f http://mirrors.kernel.org/gnu/bison/bison-2.3.tar.bz2 b10d7e9e354be72aee4e4911cf19dd27b5c527d4e7200857365b5fcdeea0dffb
-g git://git.savannah.gnu.org/gnulib.git~b28236b _ 0190f28cb155fedd22bf8558c3e8705eed9eacfb7ae29e7508d025a68eb90899 gnulib-b28236b.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~b28236b _ 0190f28cb155fedd22bf8558c3e8705eed9eacfb7ae29e7508d025a68eb90899 gnulib-b28236b.tar.gz

--- a/steps/bison-2.3/sources
+++ b/steps/bison-2.3/sources
@@ -1,2 +1,2 @@
-http://mirrors.kernel.org/gnu/bison/bison-2.3.tar.bz2 b10d7e9e354be72aee4e4911cf19dd27b5c527d4e7200857365b5fcdeea0dffb
-git://git.savannah.gnu.org/gnulib.git~b28236b _ 0190f28cb155fedd22bf8558c3e8705eed9eacfb7ae29e7508d025a68eb90899 gnulib-b28236b.tar.gz
+f http://mirrors.kernel.org/gnu/bison/bison-2.3.tar.bz2 b10d7e9e354be72aee4e4911cf19dd27b5c527d4e7200857365b5fcdeea0dffb
+g git://git.savannah.gnu.org/gnulib.git~b28236b _ 0190f28cb155fedd22bf8558c3e8705eed9eacfb7ae29e7508d025a68eb90899 gnulib-b28236b.tar.gz

--- a/steps/bison-3.4.1/sources
+++ b/steps/bison-3.4.1/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/bison/bison-3.4.1.tar.xz 27159ac5ebf736dffd5636fd2cd625767c9e437de65baa63cb0de83570bd820d
+f https://mirrors.kernel.org/gnu/bison/bison-3.4.1.tar.xz 27159ac5ebf736dffd5636fd2cd625767c9e437de65baa63cb0de83570bd820d

--- a/steps/bison-3.4.2/sources
+++ b/steps/bison-3.4.2/sources
@@ -1,2 +1,2 @@
-http://mirrors.kernel.org/gnu/bison/bison-3.4.2.tar.xz 27d05534699735dc69e86add5b808d6cb35900ad3fd63fa82e3eb644336abfa0
-git://git.savannah.gnu.org/gnulib.git~672663a _ 8cced51f89a950472473856f86e88f5daf97a2347756125ccdc8ee907deec570 gnulib-672663a.tar.gz
+f http://mirrors.kernel.org/gnu/bison/bison-3.4.2.tar.xz 27d05534699735dc69e86add5b808d6cb35900ad3fd63fa82e3eb644336abfa0
+g git://git.savannah.gnu.org/gnulib.git~672663a _ 8cced51f89a950472473856f86e88f5daf97a2347756125ccdc8ee907deec570 gnulib-672663a.tar.gz

--- a/steps/bison-3.4.2/sources
+++ b/steps/bison-3.4.2/sources
@@ -1,2 +1,2 @@
 f http://mirrors.kernel.org/gnu/bison/bison-3.4.2.tar.xz 27d05534699735dc69e86add5b808d6cb35900ad3fd63fa82e3eb644336abfa0
-g git://git.savannah.gnu.org/gnulib.git~672663a _ 8cced51f89a950472473856f86e88f5daf97a2347756125ccdc8ee907deec570 gnulib-672663a.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~672663a _ 8cced51f89a950472473856f86e88f5daf97a2347756125ccdc8ee907deec570 gnulib-672663a.tar.gz

--- a/steps/bzip2-1.0.8/sources
+++ b/steps/bzip2-1.0.8/sources
@@ -1,1 +1,1 @@
-https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+f https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269

--- a/steps/ca-certificates-3.99/sources
+++ b/steps/ca-certificates-3.99/sources
@@ -1,1 +1,1 @@
-http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_99_RTM/src/nss-3.99.tar.gz 5cd5c2c8406a376686e6fa4b9c2de38aa280bea07bf927c0d521ba07c88b09bd
+f http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_99_RTM/src/nss-3.99.tar.gz 5cd5c2c8406a376686e6fa4b9c2de38aa280bea07bf927c0d521ba07c88b09bd

--- a/steps/checksum-transcriber-1.0/checksum-transcriber-1.0.amd64.checksums
+++ b/steps/checksum-transcriber-1.0/checksum-transcriber-1.0.amd64.checksums
@@ -1,1 +1,1 @@
-80145a20564648b3a84cf9233e0da7f0a8ac4e5853512a1552de2931de09d5c0  /usr/bin/checksum-transcriber
+64978b2b50c5ba1dfb384d2d76fd7c0ddfcf330d75704881f174a3c81e7cc153  /usr/bin/checksum-transcriber

--- a/steps/checksum-transcriber-1.0/checksum-transcriber-1.0.riscv64.checksums
+++ b/steps/checksum-transcriber-1.0/checksum-transcriber-1.0.riscv64.checksums
@@ -1,1 +1,1 @@
-ef770a377283258d72595fff9900dc093d8be9d3a1052ddb3eaca0759c29b140  /usr/bin/checksum-transcriber
+1c3021d8051fefd615edb50907e3015d810f974b5b9461f8f9aa383478620a0d  /usr/bin/checksum-transcriber

--- a/steps/checksum-transcriber-1.0/checksum-transcriber-1.0.x86.checksums
+++ b/steps/checksum-transcriber-1.0/checksum-transcriber-1.0.x86.checksums
@@ -1,1 +1,1 @@
-f161bdb859c2ef76138fa20d2503ae70600b426d770e447cbb55e1a292319252  /usr/bin/checksum-transcriber
+3b43fcfe665d48c7041292bc78b3de0c5e7fe17fab425837bc5c596856d20bf8  /usr/bin/checksum-transcriber

--- a/steps/checksum-transcriber-1.0/src/checksum-transcriber.c
+++ b/steps/checksum-transcriber-1.0/src/checksum-transcriber.c
@@ -11,7 +11,7 @@
 #include <unistd.h>
 
 #define MAX_STRING 4096
-#define MAX_TOKENS 3
+#define MAX_TOKENS 8
 
 char *get_distfiles(char **envp) {
 	char *envvar = "DISTFILES=";
@@ -60,12 +60,15 @@ int main(int argc, char **argv, char **envp) {
 		}
 		line = strchr(line, '\n');
 		line[0] = '\0';
+		// Only "file" type of distfile supported at this point
+		require(strcmp(tokens[0], "f") == 0 || strcmp(tokens[0], "file") == 0,
+		        "Only support file distfile type at this point");
 		// Get checksum and filename
-		checksum = tokens[1];
-		if (tokens[2] != NULL) {
-			filename = tokens[2];
+		checksum = tokens[2];
+		if (tokens[3] != NULL) {
+			filename = tokens[3];
 		} else {
-			filename = strrchr(tokens[0], '/');
+			filename = strrchr(tokens[1], '/');
 			filename += 1;
 		}
 		// Put it all together

--- a/steps/coreutils-5.0/sources
+++ b/steps/coreutils-5.0/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/coreutils/coreutils-5.0.tar.bz2 c25b36b8af6e0ad2a875daf4d6196bd0df28a62be7dd252e5f99a4d5d7288d95
+f https://mirrors.kernel.org/gnu/coreutils/coreutils-5.0.tar.bz2 c25b36b8af6e0ad2a875daf4d6196bd0df28a62be7dd252e5f99a4d5d7288d95

--- a/steps/coreutils-6.10/sources
+++ b/steps/coreutils-6.10/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/coreutils/coreutils-6.10.tar.lzma 8b05bba1b2726a164e444c314e3f359604b58216be704bed8f2e028449cc6204
+f https://mirrors.kernel.org/gnu/coreutils/coreutils-6.10.tar.lzma 8b05bba1b2726a164e444c314e3f359604b58216be704bed8f2e028449cc6204

--- a/steps/coreutils-9.4/sources
+++ b/steps/coreutils-9.4/sources
@@ -1,17 +1,17 @@
-git://git.savannah.gnu.org/coreutils.git~v9.4 http://git.savannah.gnu.org/cgit/coreutils.git/snapshot/coreutils-9.4.tar.xz 8fb56810310253300b3d6f84e68dc97eb2d74e1f4f78e05776831d9d82e4f2d7
-git://git.savannah.gnu.org/gnulib.git~bb5bb43 _ b8aa1ac1b18c67f081486069e6a7a5564f20431c2313a94c20a46dcfb904be2a gnulib-bb5bb43.tar.gz
-http://ftp.unicode.org/Public/15.0.0/ucd/UnicodeData.txt 806e9aed65037197f1ec85e12be6e8cd870fc5608b4de0fffd990f689f376a73 UnicodeData-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/PropList.txt e05c0a2811d113dae4abd832884199a3ea8d187ee1b872d8240a788a96540bfd PropList-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/DerivedCoreProperties.txt d367290bc0867e6b484c68370530bdd1a08b6b32404601b8c7accaf83e05628d DerivedCoreProperties-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt 29071dba22c72c27783a73016afb8ffaeb025866740791f9c2d0b55cc45a3470 emoji-data-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/ArabicShaping.txt eb840f36e0a7446293578c684a54c6d83d249abde7bdd4dfa89794af1d7fe9e9 ArabicShaping-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/Scripts.txt cca85d830f46aece2e7c1459ef1249993dca8f2e46d51e869255be140d7ea4b0 Scripts-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/Blocks.txt 529dc5d0f6386d52f2f56e004bbfab48ce2d587eea9d38ba546c4052491bd820 Blocks-15.0.0.txt
-http://ftp.unicode.org/Public/3.0-Update1/PropList-3.0.1.txt 909eef4adbeddbdddcd9487c856fe8cdbb8912aa8eb315ed7885b6ef65f4dc4c
-http://ftp.unicode.org/Public/15.0.0/ucd/EastAsianWidth.txt 743e7bc435c04ab1a8459710b1c3cad56eedced5b806b4659b6e69b85d0adf2a EastAsianWidth-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/LineBreak.txt 012bca868e2c4e59a5a10a7546baf0c6fb1b2ef458c277f054915c8a49d292bf LineBreak-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/auxiliary/WordBreakProperty.txt 5188a56e91593467c2e912601ebc78750e6adc9b04541b8c5becb5441e388ce2 WordBreakProperty-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/auxiliary/GraphemeBreakProperty.txt 5a0f8748575432f8ff95e1dd5bfaa27bda1a844809e17d6939ee912bba6568a1 GraphemeBreakProperty-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/CompositionExclusions.txt 3b019c0a33c3140cbc920c078f4f9af2680ba4f71869c8d4de5190667c70b6a3 CompositionExclusions-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/SpecialCasing.txt 78b29c64b5840d25c11a9f31b665ee551b8a499eca6c70d770fcad7dd710f494 SpecialCasing-15.0.0.txt
-http://ftp.unicode.org/Public/15.0.0/ucd/CaseFolding.txt cdd49e55eae3bbf1f0a3f6580c974a0263cb86a6a08daa10fbf705b4808a56f7 CaseFolding-15.0.0.txt
+g git://git.savannah.gnu.org/coreutils.git~v9.4 http://git.savannah.gnu.org/cgit/coreutils.git/snapshot/coreutils-9.4.tar.xz 8fb56810310253300b3d6f84e68dc97eb2d74e1f4f78e05776831d9d82e4f2d7
+g git://git.savannah.gnu.org/gnulib.git~bb5bb43 _ b8aa1ac1b18c67f081486069e6a7a5564f20431c2313a94c20a46dcfb904be2a gnulib-bb5bb43.tar.gz
+f http://ftp.unicode.org/Public/15.0.0/ucd/UnicodeData.txt 806e9aed65037197f1ec85e12be6e8cd870fc5608b4de0fffd990f689f376a73 UnicodeData-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/PropList.txt e05c0a2811d113dae4abd832884199a3ea8d187ee1b872d8240a788a96540bfd PropList-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/DerivedCoreProperties.txt d367290bc0867e6b484c68370530bdd1a08b6b32404601b8c7accaf83e05628d DerivedCoreProperties-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt 29071dba22c72c27783a73016afb8ffaeb025866740791f9c2d0b55cc45a3470 emoji-data-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/ArabicShaping.txt eb840f36e0a7446293578c684a54c6d83d249abde7bdd4dfa89794af1d7fe9e9 ArabicShaping-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/Scripts.txt cca85d830f46aece2e7c1459ef1249993dca8f2e46d51e869255be140d7ea4b0 Scripts-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/Blocks.txt 529dc5d0f6386d52f2f56e004bbfab48ce2d587eea9d38ba546c4052491bd820 Blocks-15.0.0.txt
+f http://ftp.unicode.org/Public/3.0-Update1/PropList-3.0.1.txt 909eef4adbeddbdddcd9487c856fe8cdbb8912aa8eb315ed7885b6ef65f4dc4c
+f http://ftp.unicode.org/Public/15.0.0/ucd/EastAsianWidth.txt 743e7bc435c04ab1a8459710b1c3cad56eedced5b806b4659b6e69b85d0adf2a EastAsianWidth-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/LineBreak.txt 012bca868e2c4e59a5a10a7546baf0c6fb1b2ef458c277f054915c8a49d292bf LineBreak-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/auxiliary/WordBreakProperty.txt 5188a56e91593467c2e912601ebc78750e6adc9b04541b8c5becb5441e388ce2 WordBreakProperty-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/auxiliary/GraphemeBreakProperty.txt 5a0f8748575432f8ff95e1dd5bfaa27bda1a844809e17d6939ee912bba6568a1 GraphemeBreakProperty-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/CompositionExclusions.txt 3b019c0a33c3140cbc920c078f4f9af2680ba4f71869c8d4de5190667c70b6a3 CompositionExclusions-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/SpecialCasing.txt 78b29c64b5840d25c11a9f31b665ee551b8a499eca6c70d770fcad7dd710f494 SpecialCasing-15.0.0.txt
+f http://ftp.unicode.org/Public/15.0.0/ucd/CaseFolding.txt cdd49e55eae3bbf1f0a3f6580c974a0263cb86a6a08daa10fbf705b4808a56f7 CaseFolding-15.0.0.txt

--- a/steps/coreutils-9.4/sources
+++ b/steps/coreutils-9.4/sources
@@ -1,5 +1,5 @@
-g git://git.savannah.gnu.org/coreutils.git~v9.4 http://git.savannah.gnu.org/cgit/coreutils.git/snapshot/coreutils-9.4.tar.xz 8fb56810310253300b3d6f84e68dc97eb2d74e1f4f78e05776831d9d82e4f2d7
-g git://git.savannah.gnu.org/gnulib.git~bb5bb43 _ b8aa1ac1b18c67f081486069e6a7a5564f20431c2313a94c20a46dcfb904be2a gnulib-bb5bb43.tar.gz
+g https://https.git.savannah.gnu.org/git/coreutils.git~v9.4 http://git.savannah.gnu.org/cgit/coreutils.git/snapshot/coreutils-9.4.tar.xz 8fb56810310253300b3d6f84e68dc97eb2d74e1f4f78e05776831d9d82e4f2d7
+g https://https.git.savannah.gnu.org/git/gnulib.git~bb5bb43 _ b8aa1ac1b18c67f081486069e6a7a5564f20431c2313a94c20a46dcfb904be2a gnulib-bb5bb43.tar.gz
 f http://ftp.unicode.org/Public/15.0.0/ucd/UnicodeData.txt 806e9aed65037197f1ec85e12be6e8cd870fc5608b4de0fffd990f689f376a73 UnicodeData-15.0.0.txt
 f http://ftp.unicode.org/Public/15.0.0/ucd/PropList.txt e05c0a2811d113dae4abd832884199a3ea8d187ee1b872d8240a788a96540bfd PropList-15.0.0.txt
 f http://ftp.unicode.org/Public/15.0.0/ucd/DerivedCoreProperties.txt d367290bc0867e6b484c68370530bdd1a08b6b32404601b8c7accaf83e05628d DerivedCoreProperties-15.0.0.txt

--- a/steps/curl-8.12.1/sources
+++ b/steps/curl-8.12.1/sources
@@ -1,1 +1,1 @@
-https://curl.se/download/curl-8.12.1.tar.xz 0341f1ed97a26c811abaebd37d62b833956792b7607ea3f15d001613c76de202
+f https://curl.se/download/curl-8.12.1.tar.xz 0341f1ed97a26c811abaebd37d62b833956792b7607ea3f15d001613c76de202

--- a/steps/dhcpcd-10.0.1/sources
+++ b/steps/dhcpcd-10.0.1/sources
@@ -1,1 +1,1 @@
-https://github.com/NetworkConfiguration/dhcpcd/archive/refs/tags/v10.0.1.tar.gz 2bd3480bc93e6bff530872b8bc80cbcaa821449f7bf6aaf202fa12fb8c2e6f55
+f https://github.com/NetworkConfiguration/dhcpcd/archive/refs/tags/v10.0.1.tar.gz 2bd3480bc93e6bff530872b8bc80cbcaa821449f7bf6aaf202fa12fb8c2e6f55

--- a/steps/diffutils-2.7/sources
+++ b/steps/diffutils-2.7/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/diffutils/diffutils-2.7.tar.gz d5f2489c4056a31528e3ada4adacc23d498532b0af1a980f2f76158162b139d6
+f https://mirrors.kernel.org/gnu/diffutils/diffutils-2.7.tar.gz d5f2489c4056a31528e3ada4adacc23d498532b0af1a980f2f76158162b139d6

--- a/steps/diffutils-3.10/sources
+++ b/steps/diffutils-3.10/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/diffutils/diffutils-3.10.tar.xz 90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e
-g git://git.savannah.gnu.org/gnulib.git~5d2fe24 _ 72e7bb2d1d75e63d1c46d33b8dd22e8eb60afdba4af3e7251151b5c2a6f00bfb gnulib-5d2fe24.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~5d2fe24 _ 72e7bb2d1d75e63d1c46d33b8dd22e8eb60afdba4af3e7251151b5c2a6f00bfb gnulib-5d2fe24.tar.gz

--- a/steps/diffutils-3.10/sources
+++ b/steps/diffutils-3.10/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/diffutils/diffutils-3.10.tar.xz 90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e
-git://git.savannah.gnu.org/gnulib.git~5d2fe24 _ 72e7bb2d1d75e63d1c46d33b8dd22e8eb60afdba4af3e7251151b5c2a6f00bfb gnulib-5d2fe24.tar.gz
+f https://mirrors.kernel.org/gnu/diffutils/diffutils-3.10.tar.xz 90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e
+g git://git.savannah.gnu.org/gnulib.git~5d2fe24 _ 72e7bb2d1d75e63d1c46d33b8dd22e8eb60afdba4af3e7251151b5c2a6f00bfb gnulib-5d2fe24.tar.gz

--- a/steps/dist-3.5-236/sources
+++ b/steps/dist-3.5-236/sources
@@ -1,1 +1,1 @@
-g git://github.com/rmanfredi/dist~2cec35331a912b165e2dd135d22de81f34bbc83f https://github.com/rmanfredi/dist/archive/2cec35331a912b165e2dd135d22de81f34bbc83f.tar.gz 6d2c9e953de2c136c77c9b6485fbc61e8291a2a70689f2a07c79d9381bf9dbcb
+g https://github.com/rmanfredi/dist~2cec35331a912b165e2dd135d22de81f34bbc83f https://github.com/rmanfredi/dist/archive/2cec35331a912b165e2dd135d22de81f34bbc83f.tar.gz 6d2c9e953de2c136c77c9b6485fbc61e8291a2a70689f2a07c79d9381bf9dbcb

--- a/steps/dist-3.5-236/sources
+++ b/steps/dist-3.5-236/sources
@@ -1,1 +1,1 @@
-git://github.com/rmanfredi/dist~2cec35331a912b165e2dd135d22de81f34bbc83f https://github.com/rmanfredi/dist/archive/2cec35331a912b165e2dd135d22de81f34bbc83f.tar.gz 6d2c9e953de2c136c77c9b6485fbc61e8291a2a70689f2a07c79d9381bf9dbcb
+g git://github.com/rmanfredi/dist~2cec35331a912b165e2dd135d22de81f34bbc83f https://github.com/rmanfredi/dist/archive/2cec35331a912b165e2dd135d22de81f34bbc83f.tar.gz 6d2c9e953de2c136c77c9b6485fbc61e8291a2a70689f2a07c79d9381bf9dbcb

--- a/steps/e2fsprogs-1.45.7/sources
+++ b/steps/e2fsprogs-1.45.7/sources
@@ -1,8 +1,8 @@
-https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.45.7/e2fsprogs-1.45.7.tar.xz 62d49c86d9d4becf305093edd65464484dc9ea41c6ff9ae4f536e4a341b171a2
-https://www.unicode.org/Public/11.0.0/ucd/CaseFolding.txt 64f117a4749dd4a1b6c54277f63f6cf1e0eb45d290cbedaf777fbe71b8880885
-https://www.unicode.org/Public/11.0.0/ucd/DerivedAge.txt eb115a5de9a32c9ad447d6ea1cddcadb53d47f6cbc2521f3fe0bebb040c39866
-https://www.unicode.org/Public/11.0.0/ucd/extracted/DerivedCombiningClass.txt 11c8bd81ecbede4d67c7b5b693a471647d5401956707c639ae053b836cc7f5da
-https://www.unicode.org/Public/11.0.0/ucd/DerivedCoreProperties.txt 3406825d64564bf2a37031c36a3e0f99d708aa17595b81f8b539d0f3d1a3923f
-https://www.unicode.org/Public/11.0.0/ucd/NormalizationCorrections.txt c9ffe32e616fa085246644c2351c525788fac363872491185dab7d5ce69fefa9
-https://www.unicode.org/Public/11.0.0/ucd/NormalizationTest.txt 0fdfc17093dd5482f8089cb11dcd936abdba34c4c9c324e5b8a4e5d8f943f6d3
-https://www.unicode.org/Public/11.0.0/ucd/UnicodeData.txt 4997a3196eb79b4d0d6b8384560f6aeb46a062693f0abd5ba736abbff7976099
+f https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.45.7/e2fsprogs-1.45.7.tar.xz 62d49c86d9d4becf305093edd65464484dc9ea41c6ff9ae4f536e4a341b171a2
+f https://www.unicode.org/Public/11.0.0/ucd/CaseFolding.txt 64f117a4749dd4a1b6c54277f63f6cf1e0eb45d290cbedaf777fbe71b8880885
+f https://www.unicode.org/Public/11.0.0/ucd/DerivedAge.txt eb115a5de9a32c9ad447d6ea1cddcadb53d47f6cbc2521f3fe0bebb040c39866
+f https://www.unicode.org/Public/11.0.0/ucd/extracted/DerivedCombiningClass.txt 11c8bd81ecbede4d67c7b5b693a471647d5401956707c639ae053b836cc7f5da
+f https://www.unicode.org/Public/11.0.0/ucd/DerivedCoreProperties.txt 3406825d64564bf2a37031c36a3e0f99d708aa17595b81f8b539d0f3d1a3923f
+f https://www.unicode.org/Public/11.0.0/ucd/NormalizationCorrections.txt c9ffe32e616fa085246644c2351c525788fac363872491185dab7d5ce69fefa9
+f https://www.unicode.org/Public/11.0.0/ucd/NormalizationTest.txt 0fdfc17093dd5482f8089cb11dcd936abdba34c4c9c324e5b8a4e5d8f943f6d3
+f https://www.unicode.org/Public/11.0.0/ucd/UnicodeData.txt 4997a3196eb79b4d0d6b8384560f6aeb46a062693f0abd5ba736abbff7976099

--- a/steps/ed-1.4/sources
+++ b/steps/ed-1.4/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/ed/ed-1.4.tar.gz db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda
+f https://mirrors.kernel.org/gnu/ed/ed-1.4.tar.gz db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda

--- a/steps/file-5.44/sources
+++ b/steps/file-5.44/sources
@@ -1,1 +1,1 @@
-http://ftp.astron.com/pub/file/file-5.44.tar.gz 3751c7fba8dbc831cb8d7cc8aff21035459b8ce5155ef8b0880a27d028475f3b
+f http://ftp.astron.com/pub/file/file-5.44.tar.gz 3751c7fba8dbc831cb8d7cc8aff21035459b8ce5155ef8b0880a27d028475f3b

--- a/steps/findutils-4.2.33/sources
+++ b/steps/findutils-4.2.33/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/findutils/findutils-4.2.33.tar.gz 813cd9405aceec5cfecbe96400d01e90ddad7b512d3034487176ce5258ab0f78
-git://git.savannah.gnu.org/gnulib.git~8e128e _ 0cfbf866bc39c31f25fa0e56af1e56c5e5c92fc1e5d51242ebafef7ea211f3d5 gnulib-8e128e.tar.gz
+f https://mirrors.kernel.org/gnu/findutils/findutils-4.2.33.tar.gz 813cd9405aceec5cfecbe96400d01e90ddad7b512d3034487176ce5258ab0f78
+g git://git.savannah.gnu.org/gnulib.git~8e128e _ 0cfbf866bc39c31f25fa0e56af1e56c5e5c92fc1e5d51242ebafef7ea211f3d5 gnulib-8e128e.tar.gz

--- a/steps/findutils-4.2.33/sources
+++ b/steps/findutils-4.2.33/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/findutils/findutils-4.2.33.tar.gz 813cd9405aceec5cfecbe96400d01e90ddad7b512d3034487176ce5258ab0f78
-g git://git.savannah.gnu.org/gnulib.git~8e128e _ 0cfbf866bc39c31f25fa0e56af1e56c5e5c92fc1e5d51242ebafef7ea211f3d5 gnulib-8e128e.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~8e128e _ 0cfbf866bc39c31f25fa0e56af1e56c5e5c92fc1e5d51242ebafef7ea211f3d5 gnulib-8e128e.tar.gz

--- a/steps/fiwix-1.5.0-lb1/sources
+++ b/steps/fiwix-1.5.0-lb1/sources
@@ -1,1 +1,1 @@
-https://github.com/mikaku/Fiwix/releases/download/v1.5.0-lb1/fiwix-1.5.0-lb1.tar.gz 6635f8b8a44694a374daccd528a8d22550e684d33dc967f7fa2d161b9d69deb4
+f https://github.com/mikaku/Fiwix/releases/download/v1.5.0-lb1/fiwix-1.5.0-lb1.tar.gz 6635f8b8a44694a374daccd528a8d22550e684d33dc967f7fa2d161b9d69deb4

--- a/steps/flex-2.5.11/sources
+++ b/steps/flex-2.5.11/sources
@@ -1,1 +1,1 @@
-g git://github.com/westes/flex~d160f0247ba1611aa59d28f027d6292ba24abb50 https://github.com/westes/flex/archive/d160f0247ba1611aa59d28f027d6292ba24abb50.tar.gz 68aa10c473b6010ffad680cada09fc4eec6b3cc6e415cc2339e5fc2385ccc142
+g https://github.com/westes/flex~d160f0247ba1611aa59d28f027d6292ba24abb50 https://github.com/westes/flex/archive/d160f0247ba1611aa59d28f027d6292ba24abb50.tar.gz 68aa10c473b6010ffad680cada09fc4eec6b3cc6e415cc2339e5fc2385ccc142

--- a/steps/flex-2.5.11/sources
+++ b/steps/flex-2.5.11/sources
@@ -1,1 +1,1 @@
-git://github.com/westes/flex~d160f0247ba1611aa59d28f027d6292ba24abb50 https://github.com/westes/flex/archive/d160f0247ba1611aa59d28f027d6292ba24abb50.tar.gz 68aa10c473b6010ffad680cada09fc4eec6b3cc6e415cc2339e5fc2385ccc142
+g git://github.com/westes/flex~d160f0247ba1611aa59d28f027d6292ba24abb50 https://github.com/westes/flex/archive/d160f0247ba1611aa59d28f027d6292ba24abb50.tar.gz 68aa10c473b6010ffad680cada09fc4eec6b3cc6e415cc2339e5fc2385ccc142

--- a/steps/flex-2.5.33/sources
+++ b/steps/flex-2.5.33/sources
@@ -1,1 +1,1 @@
-g git://github.com/westes/flex~e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea https://github.com/westes/flex/archive/e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea.tar.gz baec69069ff58b7cdbe0103ffc16f29d4857428c29efcdf685c574d8300fd838
+g https://github.com/westes/flex~e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea https://github.com/westes/flex/archive/e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea.tar.gz baec69069ff58b7cdbe0103ffc16f29d4857428c29efcdf685c574d8300fd838

--- a/steps/flex-2.5.33/sources
+++ b/steps/flex-2.5.33/sources
@@ -1,1 +1,1 @@
-git://github.com/westes/flex~e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea https://github.com/westes/flex/archive/e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea.tar.gz baec69069ff58b7cdbe0103ffc16f29d4857428c29efcdf685c574d8300fd838
+g git://github.com/westes/flex~e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea https://github.com/westes/flex/archive/e6f147b7a5f2ec2dc862dc9d30b3734b9555a1ea.tar.gz baec69069ff58b7cdbe0103ffc16f29d4857428c29efcdf685c574d8300fd838

--- a/steps/flex-2.6.4/sources
+++ b/steps/flex-2.6.4/sources
@@ -1,1 +1,1 @@
-https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
+f https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995

--- a/steps/gawk-3.0.4/sources
+++ b/steps/gawk-3.0.4/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/gawk/gawk-3.0.4.tar.gz 5cc35def1ff4375a8b9a98c2ff79e95e80987d24f0d42fdbb7b7039b3ddb3fb0
+f https://mirrors.kernel.org/gnu/gawk/gawk-3.0.4.tar.gz 5cc35def1ff4375a8b9a98c2ff79e95e80987d24f0d42fdbb7b7039b3ddb3fb0

--- a/steps/gawk-5.3.0/sources
+++ b/steps/gawk-5.3.0/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/gawk/gawk-5.3.0.tar.xz ca9c16d3d11d0ff8c69d79dc0b47267e1329a69b39b799895604ed447d3ca90b
+f https://mirrors.kernel.org/gnu/gawk/gawk-5.3.0.tar.xz ca9c16d3d11d0ff8c69d79dc0b47267e1329a69b39b799895604ed447d3ca90b

--- a/steps/gc-8.0.4/sources
+++ b/steps/gc-8.0.4/sources
@@ -1,1 +1,1 @@
-https://www.hboehm.info/gc/gc_source/gc-8.0.4.tar.gz 436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d
+f https://www.hboehm.info/gc/gc_source/gc-8.0.4.tar.gz 436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d

--- a/steps/gcc-10.5.0/sources
+++ b/steps/gcc-10.5.0/sources
@@ -1,1 +1,1 @@
-f http://ftp.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz 25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1
+f https://mirrors.kernel.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz 25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1

--- a/steps/gcc-10.5.0/sources
+++ b/steps/gcc-10.5.0/sources
@@ -1,1 +1,1 @@
-http://ftp.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz 25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1
+f http://ftp.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz 25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1

--- a/steps/gcc-15.2.0/sources
+++ b/steps/gcc-15.2.0/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz 438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e
-https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html 835a4d043e4415a76668c8f38d5605f4e6f8ac2279dfab7e61c3f06e9228dd1c
+f https://mirrors.kernel.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz 438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e
+f https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html 835a4d043e4415a76668c8f38d5605f4e6f8ac2279dfab7e61c3f06e9228dd1c

--- a/steps/gcc-4.0.4/sources
+++ b/steps/gcc-4.0.4/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/gcc/gcc-4.0.4/gcc-core-4.0.4.tar.bz2 e9bf58c761a4f988311aef6b41f12fd5c7e51d09477468fb73826aecc1be32e7
-https://mirrors.kernel.org/gnu/automake/automake-1.16.3.tar.xz ff2bf7656c4d1c6fdda3b8bebb21f09153a736bcba169aaf65eab25fa113bf3a
+f https://mirrors.kernel.org/gnu/gcc/gcc-4.0.4/gcc-core-4.0.4.tar.bz2 e9bf58c761a4f988311aef6b41f12fd5c7e51d09477468fb73826aecc1be32e7
+f https://mirrors.kernel.org/gnu/automake/automake-1.16.3.tar.xz ff2bf7656c4d1c6fdda3b8bebb21f09153a736bcba169aaf65eab25fa113bf3a

--- a/steps/gcc-4.7.4/sources
+++ b/steps/gcc-4.7.4/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2 92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282
+f https://mirrors.kernel.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2 92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282

--- a/steps/gettext-0.21/sources
+++ b/steps/gettext-0.21/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/gettext/gettext-0.21.tar.xz d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192
-git://git.savannah.gnu.org/gnulib.git~7daa86f _ 2d911c2f2ed97b347d6d360b742abdc98aa626d4f8f847ee682c7cde12e90871 gnulib-7daa86f.tar.gz
+f https://mirrors.kernel.org/gnu/gettext/gettext-0.21.tar.xz d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192
+g git://git.savannah.gnu.org/gnulib.git~7daa86f _ 2d911c2f2ed97b347d6d360b742abdc98aa626d4f8f847ee682c7cde12e90871 gnulib-7daa86f.tar.gz

--- a/steps/gettext-0.21/sources
+++ b/steps/gettext-0.21/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/gettext/gettext-0.21.tar.xz d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192
-g git://git.savannah.gnu.org/gnulib.git~7daa86f _ 2d911c2f2ed97b347d6d360b742abdc98aa626d4f8f847ee682c7cde12e90871 gnulib-7daa86f.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~7daa86f _ 2d911c2f2ed97b347d6d360b742abdc98aa626d4f8f847ee682c7cde12e90871 gnulib-7daa86f.tar.gz

--- a/steps/gmp-6.2.1/sources
+++ b/steps/gmp-6.2.1/sources
@@ -1,1 +1,1 @@
-http://mirrors.kernel.org/gnu/gmp/gmp-6.2.1.tar.xz fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
+f http://mirrors.kernel.org/gnu/gmp/gmp-6.2.1.tar.xz fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2

--- a/steps/gperf-3.1/sources
+++ b/steps/gperf-3.1/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/gperf/gperf-3.1.tar.gz 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
+f https://mirrors.kernel.org/gnu/gperf/gperf-3.1.tar.gz 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2

--- a/steps/grep-2.4/sources
+++ b/steps/grep-2.4/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/grep/grep-2.4.tar.gz a32032bab36208509466654df12f507600dfe0313feebbcd218c32a70bf72a16
+f https://mirrors.kernel.org/gnu/grep/grep-2.4.tar.gz a32032bab36208509466654df12f507600dfe0313feebbcd218c32a70bf72a16

--- a/steps/grep-3.7/sources
+++ b/steps/grep-3.7/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/grep/grep-3.7.tar.xz 5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c
-git://git.savannah.gnu.org/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz
+f https://mirrors.kernel.org/gnu/grep/grep-3.7.tar.xz 5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c
+g git://git.savannah.gnu.org/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz

--- a/steps/grep-3.7/sources
+++ b/steps/grep-3.7/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/grep/grep-3.7.tar.xz 5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c
-g git://git.savannah.gnu.org/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~8f4538a5 _ e207c0bb72093c3a72dde302fcfaa1dbda12a62172d47b73565883a92209ebab gnulib-8f4538a5.tar.gz

--- a/steps/grub-2.06/sources
+++ b/steps/grub-2.06/sources
@@ -1,16 +1,16 @@
-https://mirrors.kernel.org/gnu/grub/grub-2.06.tar.xz b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1
-git://git.savannah.gnu.org/gnulib.git~d271f86 _ 31d69d3d251e39135b5194ddc6f897910d344059f7494d96a739aecbf7ac2b66 gnulib-d271f86.tar.gz
-http://ftp.unicode.org/Public/9.0.0/ucd/UnicodeData.txt 68dfc414d28257b9b5d6ddbb8b466c768c00ebdf6cbf7784364a9b6cad55ee8f UnicodeData-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/PropList.txt f413ea8dbd3858de72f3148b47dd0586019761357d1481e3b65f3a025bc27f82 PropList-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/DerivedCoreProperties.txt 6662c7e30b572df5d948c092692f52bcc79ab36d49a063a73d6435042db6fb3b DerivedCoreProperties-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/ArabicShaping.txt 47cb62a53beea6d0263e2147331c7e751853c9327225d95bbe2d9e1dc3e1aa44 ArabicShaping-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/Scripts.txt fba415952f5654145acad220dc2b878f815c673474d2bb4928934e3ba6ccca1d Scripts-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/Blocks.txt 612127d4889032e55d82522e4a0c19793bda8aa8da14ecb3c696d17c83e6be13 Blocks-9.0.0.txt
-http://ftp.unicode.org/Public/3.0-Update1/PropList-3.0.1.txt 909eef4adbeddbdddcd9487c856fe8cdbb8912aa8eb315ed7885b6ef65f4dc4c
-http://ftp.unicode.org/Public/9.0.0/ucd/EastAsianWidth.txt 3382cb4980e0021e9d4312f2d099315cfab6100ce0ff63a22d6937bfa720bcb7 EastAsianWidth-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/LineBreak.txt e2698584982ccd96e0c688bbcd4d2c48a23805baa0a0084388ef2e50ebd30aad LineBreak-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/auxiliary/WordBreakProperty.txt cb2db065c77287e0f1d35b8c9b473d848b7566a1670439f67c357ca393084043 WordBreakProperty-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/auxiliary/GraphemeBreakProperty.txt 4bb8931857e0a698fd2ec4a51a84c6de33e48a50d8b4bf0b57d960c41d77a191 GraphemeBreakProperty-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/CompositionExclusions.txt 5623df16856ad4007c60bdfff6f054e087521becd24cb4006be69c3a1d851aee CompositionExclusions-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/SpecialCasing.txt dfc4f159c5c68328114ff17cd520451714a72ff48657287e5fe2f64344980695 SpecialCasing-9.0.0.txt
-http://ftp.unicode.org/Public/9.0.0/ucd/CaseFolding.txt 37d40cf8c2c35637f4a04e746814e1fc4eb764c272bed9238a87ee96a4866857 CaseFolding-9.0.0.txt
+f https://mirrors.kernel.org/gnu/grub/grub-2.06.tar.xz b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1
+g git://git.savannah.gnu.org/gnulib.git~d271f86 _ 31d69d3d251e39135b5194ddc6f897910d344059f7494d96a739aecbf7ac2b66 gnulib-d271f86.tar.gz
+f http://ftp.unicode.org/Public/9.0.0/ucd/UnicodeData.txt 68dfc414d28257b9b5d6ddbb8b466c768c00ebdf6cbf7784364a9b6cad55ee8f UnicodeData-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/PropList.txt f413ea8dbd3858de72f3148b47dd0586019761357d1481e3b65f3a025bc27f82 PropList-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/DerivedCoreProperties.txt 6662c7e30b572df5d948c092692f52bcc79ab36d49a063a73d6435042db6fb3b DerivedCoreProperties-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/ArabicShaping.txt 47cb62a53beea6d0263e2147331c7e751853c9327225d95bbe2d9e1dc3e1aa44 ArabicShaping-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/Scripts.txt fba415952f5654145acad220dc2b878f815c673474d2bb4928934e3ba6ccca1d Scripts-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/Blocks.txt 612127d4889032e55d82522e4a0c19793bda8aa8da14ecb3c696d17c83e6be13 Blocks-9.0.0.txt
+f http://ftp.unicode.org/Public/3.0-Update1/PropList-3.0.1.txt 909eef4adbeddbdddcd9487c856fe8cdbb8912aa8eb315ed7885b6ef65f4dc4c
+f http://ftp.unicode.org/Public/9.0.0/ucd/EastAsianWidth.txt 3382cb4980e0021e9d4312f2d099315cfab6100ce0ff63a22d6937bfa720bcb7 EastAsianWidth-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/LineBreak.txt e2698584982ccd96e0c688bbcd4d2c48a23805baa0a0084388ef2e50ebd30aad LineBreak-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/auxiliary/WordBreakProperty.txt cb2db065c77287e0f1d35b8c9b473d848b7566a1670439f67c357ca393084043 WordBreakProperty-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/auxiliary/GraphemeBreakProperty.txt 4bb8931857e0a698fd2ec4a51a84c6de33e48a50d8b4bf0b57d960c41d77a191 GraphemeBreakProperty-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/CompositionExclusions.txt 5623df16856ad4007c60bdfff6f054e087521becd24cb4006be69c3a1d851aee CompositionExclusions-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/SpecialCasing.txt dfc4f159c5c68328114ff17cd520451714a72ff48657287e5fe2f64344980695 SpecialCasing-9.0.0.txt
+f http://ftp.unicode.org/Public/9.0.0/ucd/CaseFolding.txt 37d40cf8c2c35637f4a04e746814e1fc4eb764c272bed9238a87ee96a4866857 CaseFolding-9.0.0.txt

--- a/steps/grub-2.06/sources
+++ b/steps/grub-2.06/sources
@@ -1,5 +1,5 @@
 f https://mirrors.kernel.org/gnu/grub/grub-2.06.tar.xz b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1
-g git://git.savannah.gnu.org/gnulib.git~d271f86 _ 31d69d3d251e39135b5194ddc6f897910d344059f7494d96a739aecbf7ac2b66 gnulib-d271f86.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~d271f86 _ 31d69d3d251e39135b5194ddc6f897910d344059f7494d96a739aecbf7ac2b66 gnulib-d271f86.tar.gz
 f http://ftp.unicode.org/Public/9.0.0/ucd/UnicodeData.txt 68dfc414d28257b9b5d6ddbb8b466c768c00ebdf6cbf7784364a9b6cad55ee8f UnicodeData-9.0.0.txt
 f http://ftp.unicode.org/Public/9.0.0/ucd/PropList.txt f413ea8dbd3858de72f3148b47dd0586019761357d1481e3b65f3a025bc27f82 PropList-9.0.0.txt
 f http://ftp.unicode.org/Public/9.0.0/ucd/DerivedCoreProperties.txt 6662c7e30b572df5d948c092692f52bcc79ab36d49a063a73d6435042db6fb3b DerivedCoreProperties-9.0.0.txt

--- a/steps/guile-3.0.9/sources
+++ b/steps/guile-3.0.9/sources
@@ -1,5 +1,5 @@
-https://mirrors.kernel.org/gnu/guile/guile-3.0.7.tar.xz f57d86c70620271bfceb7a9be0c81744a033f08adc7ceba832c9917ab3e691b7
-https://mirrors.kernel.org/gnu/guile/guile-3.0.9.tar.xz 1a2625ac72b2366e95792f3fe758fd2df775b4044a90a4a9787326e66c0d750d 
-git://git.savannah.gnu.org/gnulib.git~901694b9 _ f9aad85de1f41d57c9368d304020ffbf354a5e56db1297f022c3d12181134e56 gnulib-901694b9.tar.gz
-git://git.savannah.gnu.org/gnulib.git~356a414e _ fc9973f1a9243fdc4b98d33d7704f3c71bfdc4c2ef96899b8f28cade7290a714 gnulib-356a414e.tar.gz
-git://github.com/schierlm/guile-psyntax-bootstrapping~guile-3.0.7 https://github.com/schierlm/guile-psyntax-bootstrapping/archive/refs/tags/guile-3.0.7.tar.gz 14cda9c416506dfadf60c14fc623ff01ef99b87564a78d0a29c5d17143c97609
+f https://mirrors.kernel.org/gnu/guile/guile-3.0.7.tar.xz f57d86c70620271bfceb7a9be0c81744a033f08adc7ceba832c9917ab3e691b7
+f https://mirrors.kernel.org/gnu/guile/guile-3.0.9.tar.xz 1a2625ac72b2366e95792f3fe758fd2df775b4044a90a4a9787326e66c0d750d 
+g git://git.savannah.gnu.org/gnulib.git~901694b9 _ f9aad85de1f41d57c9368d304020ffbf354a5e56db1297f022c3d12181134e56 gnulib-901694b9.tar.gz
+g git://git.savannah.gnu.org/gnulib.git~356a414e _ fc9973f1a9243fdc4b98d33d7704f3c71bfdc4c2ef96899b8f28cade7290a714 gnulib-356a414e.tar.gz
+g git://github.com/schierlm/guile-psyntax-bootstrapping~guile-3.0.7 https://github.com/schierlm/guile-psyntax-bootstrapping/archive/refs/tags/guile-3.0.7.tar.gz 14cda9c416506dfadf60c14fc623ff01ef99b87564a78d0a29c5d17143c97609

--- a/steps/guile-3.0.9/sources
+++ b/steps/guile-3.0.9/sources
@@ -1,5 +1,5 @@
 f https://mirrors.kernel.org/gnu/guile/guile-3.0.7.tar.xz f57d86c70620271bfceb7a9be0c81744a033f08adc7ceba832c9917ab3e691b7
 f https://mirrors.kernel.org/gnu/guile/guile-3.0.9.tar.xz 1a2625ac72b2366e95792f3fe758fd2df775b4044a90a4a9787326e66c0d750d 
-g git://git.savannah.gnu.org/gnulib.git~901694b9 _ f9aad85de1f41d57c9368d304020ffbf354a5e56db1297f022c3d12181134e56 gnulib-901694b9.tar.gz
-g git://git.savannah.gnu.org/gnulib.git~356a414e _ fc9973f1a9243fdc4b98d33d7704f3c71bfdc4c2ef96899b8f28cade7290a714 gnulib-356a414e.tar.gz
-g git://github.com/schierlm/guile-psyntax-bootstrapping~guile-3.0.7 https://github.com/schierlm/guile-psyntax-bootstrapping/archive/refs/tags/guile-3.0.7.tar.gz 14cda9c416506dfadf60c14fc623ff01ef99b87564a78d0a29c5d17143c97609
+g https://https.git.savannah.gnu.org/git/gnulib.git~901694b9 _ f9aad85de1f41d57c9368d304020ffbf354a5e56db1297f022c3d12181134e56 gnulib-901694b9.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~356a414e _ fc9973f1a9243fdc4b98d33d7704f3c71bfdc4c2ef96899b8f28cade7290a714 gnulib-356a414e.tar.gz
+g https://github.com/schierlm/guile-psyntax-bootstrapping~guile-3.0.7 https://github.com/schierlm/guile-psyntax-bootstrapping/archive/refs/tags/guile-3.0.7.tar.gz 14cda9c416506dfadf60c14fc623ff01ef99b87564a78d0a29c5d17143c97609

--- a/steps/gzip-1.13/sources
+++ b/steps/gzip-1.13/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/gzip/gzip-1.13.tar.xz 7454eb6935db17c6655576c2e1b0fabefd38b4d0936e0f87f48cd062ce91a057
-git://git.savannah.gnu.org/gnulib.git~5651802 _ 56f1221eb682c3502ee097f583f44673570753cb452346ad4806d94560c3fac9 gnulib-5651802.tar.gz
+f https://mirrors.kernel.org/gnu/gzip/gzip-1.13.tar.xz 7454eb6935db17c6655576c2e1b0fabefd38b4d0936e0f87f48cd062ce91a057
+g git://git.savannah.gnu.org/gnulib.git~5651802 _ 56f1221eb682c3502ee097f583f44673570753cb452346ad4806d94560c3fac9 gnulib-5651802.tar.gz

--- a/steps/gzip-1.13/sources
+++ b/steps/gzip-1.13/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/gzip/gzip-1.13.tar.xz 7454eb6935db17c6655576c2e1b0fabefd38b4d0936e0f87f48cd062ce91a057
-g git://git.savannah.gnu.org/gnulib.git~5651802 _ 56f1221eb682c3502ee097f583f44673570753cb452346ad4806d94560c3fac9 gnulib-5651802.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~5651802 _ 56f1221eb682c3502ee097f583f44673570753cb452346ad4806d94560c3fac9 gnulib-5651802.tar.gz

--- a/steps/gzip-1.2.4/sources
+++ b/steps/gzip-1.2.4/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/gzip/gzip-1.2.4.tar.gz 1ca41818a23c9c59ef1d5e1d00c0d5eaa2285d931c0fb059637d7c0cc02ad967
+f https://mirrors.kernel.org/gnu/gzip/gzip-1.2.4.tar.gz 1ca41818a23c9c59ef1d5e1d00c0d5eaa2285d931c0fb059637d7c0cc02ad967

--- a/steps/heirloom-devtools-070527/sources
+++ b/steps/heirloom-devtools-070527/sources
@@ -1,1 +1,1 @@
-http://downloads.sourceforge.net/project/heirloom/heirloom-devtools/070527/heirloom-devtools-070527.tar.bz2 9f233d8b78e4351fe9dd2d50d83958a0e5af36f54e9818521458a08e058691ba
+f http://downloads.sourceforge.net/project/heirloom/heirloom-devtools/070527/heirloom-devtools-070527.tar.bz2 9f233d8b78e4351fe9dd2d50d83958a0e5af36f54e9818521458a08e058691ba

--- a/steps/help2man-1.36.4/sources
+++ b/steps/help2man-1.36.4/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/help2man/help2man-1.36.4.tar.gz a4adadf76b496a6bc50795702253ecfcb6f0d159b68038f31a5362009340bca2
+f https://mirrors.kernel.org/gnu/help2man/help2man-1.36.4.tar.gz a4adadf76b496a6bc50795702253ecfcb6f0d159b68038f31a5362009340bca2

--- a/steps/improve/clean_sources.sh
+++ b/steps/improve/clean_sources.sh
@@ -6,9 +6,6 @@
 # Delete sources of packages before linux kernel
 
 get_source_filename() {
-    if [[ "${1}" == git://* ]]; then
-        shift
-    fi
     local url="${1}"
     local fname="${3}"
     # Default to basename of url if not given
@@ -24,7 +21,7 @@ pkgs="$(awk '/^build:/ { print $2 }' "${SRCDIR}/manifest" | awk '/^linux-[0-9]/,
 keep_sources=""
 for pkg in ${pkgs}; do
     while read line; do
-        keep_sources="${keep_sources} $(get_source_filename ${line})"
+        keep_sources="${keep_sources} $(source_line_action get_source_filename ${line})"
     done < "${SRCDIR}/${pkg}/sources"
 done
 

--- a/steps/kbd-1.15/sources
+++ b/steps/kbd-1.15/sources
@@ -1,1 +1,1 @@
-https://mirrors.edge.kernel.org/pub/linux/utils/kbd/kbd-1.15.tar.xz 92f59ecaa85fe2746ef1830ac01eef84c394a413f7c7326b8d0a5c819e87502f
+f https://mirrors.edge.kernel.org/pub/linux/utils/kbd/kbd-1.15.tar.xz 92f59ecaa85fe2746ef1830ac01eef84c394a413f7c7326b8d0a5c819e87502f

--- a/steps/kexec-tools-2.0.22/sources
+++ b/steps/kexec-tools-2.0.22/sources
@@ -1,1 +1,1 @@
-git://github.com/horms/kexec-tools~v2.0.22 https://github.com/horms/kexec-tools/archive/refs/tags/v2.0.22.tar.gz af618de7848142f204b57811f703de3ae7aa3f5bc5d52226db35800fa8fc4dff
+g git://github.com/horms/kexec-tools~v2.0.22 https://github.com/horms/kexec-tools/archive/refs/tags/v2.0.22.tar.gz af618de7848142f204b57811f703de3ae7aa3f5bc5d52226db35800fa8fc4dff

--- a/steps/kexec-tools-2.0.22/sources
+++ b/steps/kexec-tools-2.0.22/sources
@@ -1,1 +1,1 @@
-g git://github.com/horms/kexec-tools~v2.0.22 https://github.com/horms/kexec-tools/archive/refs/tags/v2.0.22.tar.gz af618de7848142f204b57811f703de3ae7aa3f5bc5d52226db35800fa8fc4dff
+g https://github.com/horms/kexec-tools~v2.0.22 https://github.com/horms/kexec-tools/archive/refs/tags/v2.0.22.tar.gz af618de7848142f204b57811f703de3ae7aa3f5bc5d52226db35800fa8fc4dff

--- a/steps/libarchive-3.5.2/sources
+++ b/steps/libarchive-3.5.2/sources
@@ -1,1 +1,1 @@
-http://libarchive.org/downloads/libarchive-3.5.2.tar.xz f0b19ff39c3c9a5898a219497ababbadab99d8178acc980155c7e1271089b5a0
+f http://libarchive.org/downloads/libarchive-3.5.2.tar.xz f0b19ff39c3c9a5898a219497ababbadab99d8178acc980155c7e1271089b5a0

--- a/steps/libatomic_ops-7.6.10/sources
+++ b/steps/libatomic_ops-7.6.10/sources
@@ -1,1 +1,1 @@
-https://www.hboehm.info/gc/gc_source/libatomic_ops-7.6.10.tar.gz 587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af
+f https://www.hboehm.info/gc/gc_source/libatomic_ops-7.6.10.tar.gz 587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af

--- a/steps/libbsd-0.11.8/sources
+++ b/steps/libbsd-0.11.8/sources
@@ -1,1 +1,1 @@
-https://libbsd.freedesktop.org/releases/libbsd-0.11.8.tar.xz 55fdfa2696fb4d55a592fa9ad14a9df897c7b0008ddb3b30c419914841f85f33
+f https://libbsd.freedesktop.org/releases/libbsd-0.11.8.tar.xz 55fdfa2696fb4d55a592fa9ad14a9df897c7b0008ddb3b30c419914841f85f33

--- a/steps/libffi-3.3/sources
+++ b/steps/libffi-3.3/sources
@@ -1,1 +1,1 @@
-https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz 72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056
+f https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz 72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056

--- a/steps/libmd-1.1.0/sources
+++ b/steps/libmd-1.1.0/sources
@@ -1,1 +1,1 @@
-https://archive.hadrons.org/software/libmd/libmd-1.1.0.tar.xz 1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332
+f https://archive.hadrons.org/software/libmd/libmd-1.1.0.tar.xz 1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332

--- a/steps/libtool-2.2.4/sources
+++ b/steps/libtool-2.2.4/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/libtool/libtool-2.2.4.tar.lzma d81839fa4d566dbef7c286fdca9b430d3530983fff6d389fac0f08baf27e4c3a
+f https://mirrors.kernel.org/gnu/libtool/libtool-2.2.4.tar.lzma d81839fa4d566dbef7c286fdca9b430d3530983fff6d389fac0f08baf27e4c3a

--- a/steps/libtool-2.4.7/sources
+++ b/steps/libtool-2.4.7/sources
@@ -1,2 +1,2 @@
-http://mirrors.kernel.org/gnu/libtool/libtool-2.4.7.tar.xz 4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d
-git://git.savannah.gnu.org/gnulib.git~a521820 _ 719b399fe09a8f6ca14ba8c4a9a60ce9f93f4892effb50961ef3d8cd1a33ff65 gnulib-a521820.tar.gz
+f http://mirrors.kernel.org/gnu/libtool/libtool-2.4.7.tar.xz 4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d
+g git://git.savannah.gnu.org/gnulib.git~a521820 _ 719b399fe09a8f6ca14ba8c4a9a60ce9f93f4892effb50961ef3d8cd1a33ff65 gnulib-a521820.tar.gz

--- a/steps/libtool-2.4.7/sources
+++ b/steps/libtool-2.4.7/sources
@@ -1,2 +1,2 @@
 f http://mirrors.kernel.org/gnu/libtool/libtool-2.4.7.tar.xz 4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d
-g git://git.savannah.gnu.org/gnulib.git~a521820 _ 719b399fe09a8f6ca14ba8c4a9a60ce9f93f4892effb50961ef3d8cd1a33ff65 gnulib-a521820.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~a521820 _ 719b399fe09a8f6ca14ba8c4a9a60ce9f93f4892effb50961ef3d8cd1a33ff65 gnulib-a521820.tar.gz

--- a/steps/libunistring-0.9.10/sources
+++ b/steps/libunistring-0.9.10/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/libunistring/libunistring-0.9.10.tar.xz eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7
-git://git.savannah.gnu.org/gnulib.git~52a06cb3 _ 009989b81c0bebc5f6550636ed653fbcb237dafc2af5c706f3522087ca571e4d gnulib-52a06cb3.tar.gz
+f https://mirrors.kernel.org/gnu/libunistring/libunistring-0.9.10.tar.xz eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7
+g git://git.savannah.gnu.org/gnulib.git~52a06cb3 _ 009989b81c0bebc5f6550636ed653fbcb237dafc2af5c706f3522087ca571e4d gnulib-52a06cb3.tar.gz

--- a/steps/libunistring-0.9.10/sources
+++ b/steps/libunistring-0.9.10/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/libunistring/libunistring-0.9.10.tar.xz eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7
-g git://git.savannah.gnu.org/gnulib.git~52a06cb3 _ 009989b81c0bebc5f6550636ed653fbcb237dafc2af5c706f3522087ca571e4d gnulib-52a06cb3.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~52a06cb3 _ 009989b81c0bebc5f6550636ed653fbcb237dafc2af5c706f3522087ca571e4d gnulib-52a06cb3.tar.gz

--- a/steps/linux-4.14.341-openela/sources
+++ b/steps/linux-4.14.341-openela/sources
@@ -1,1 +1,1 @@
-https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.14.336.tar.xz 0820fdb7971c6974338081c11fbf2dc869870501e7bdcac4d0ed58ba1f57b61c
+f https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.14.336.tar.xz 0820fdb7971c6974338081c11fbf2dc869870501e7bdcac4d0ed58ba1f57b61c

--- a/steps/linux-headers-4.14.341-openela/sources
+++ b/steps/linux-headers-4.14.341-openela/sources
@@ -1,1 +1,1 @@
-https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.14.336.tar.xz 0820fdb7971c6974338081c11fbf2dc869870501e7bdcac4d0ed58ba1f57b61c
+f https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.14.336.tar.xz 0820fdb7971c6974338081c11fbf2dc869870501e7bdcac4d0ed58ba1f57b61c

--- a/steps/lwext4-1.0.0-lb1/sources
+++ b/steps/lwext4-1.0.0-lb1/sources
@@ -1,1 +1,1 @@
-https://github.com/rick-masters/lwext4/releases/download/v1.0.0-lb1/lwext4-1.0.0-lb1.tar.gz a90526665123d788fc23d14354468d22cc2e3e9e43a6c44ea452fbbec12b8451
+f https://github.com/rick-masters/lwext4/releases/download/v1.0.0-lb1/lwext4-1.0.0-lb1.tar.gz a90526665123d788fc23d14354468d22cc2e3e9e43a6c44ea452fbbec12b8451

--- a/steps/m4-1.4.19/sources
+++ b/steps/m4-1.4.19/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz 63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96
-git://git.savannah.gnu.org/gnulib.git~3639c57 _ 97dfbad67832641bc7f73437617b78abeafb9946723f19cf4c2ceecfc65fa48d gnulib-3639c57.tar.gz
+f https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz 63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96
+g git://git.savannah.gnu.org/gnulib.git~3639c57 _ 97dfbad67832641bc7f73437617b78abeafb9946723f19cf4c2ceecfc65fa48d gnulib-3639c57.tar.gz

--- a/steps/m4-1.4.19/sources
+++ b/steps/m4-1.4.19/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz 63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96
-g git://git.savannah.gnu.org/gnulib.git~3639c57 _ 97dfbad67832641bc7f73437617b78abeafb9946723f19cf4c2ceecfc65fa48d gnulib-3639c57.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~3639c57 _ 97dfbad67832641bc7f73437617b78abeafb9946723f19cf4c2ceecfc65fa48d gnulib-3639c57.tar.gz

--- a/steps/m4-1.4.7/sources
+++ b/steps/m4-1.4.7/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/m4/m4-1.4.7.tar.bz2 a88f3ddaa7c89cf4c34284385be41ca85e9135369c333fdfa232f3bf48223213
+f https://mirrors.kernel.org/gnu/m4/m4-1.4.7.tar.bz2 a88f3ddaa7c89cf4c34284385be41ca85e9135369c333fdfa232f3bf48223213

--- a/steps/make-3.82/sources
+++ b/steps/make-3.82/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/make/make-3.82.tar.bz2 e2c1a73f179c40c71e2fe8abf8a8a0688b8499538512984da4a76958d0402966
+f https://mirrors.kernel.org/gnu/make/make-3.82.tar.bz2 e2c1a73f179c40c71e2fe8abf8a8a0688b8499538512984da4a76958d0402966

--- a/steps/make-4.2.1/sources
+++ b/steps/make-4.2.1/sources
@@ -1,1 +1,1 @@
-f http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7
+f https://mirrors.kernel.org/gnu/make/make-4.2.1.tar.gz e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7

--- a/steps/make-4.2.1/sources
+++ b/steps/make-4.2.1/sources
@@ -1,1 +1,1 @@
-http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7
+f http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7

--- a/steps/mes-0.27.1/sources
+++ b/steps/mes-0.27.1/sources
@@ -1,4 +1,4 @@
-https://mirrors.kernel.org/gnu/mes/mes-0.27.1.tar.gz 183a40ea47ea49f8a1e3bd1b9d12e676374d64d63bc79e7bc1ae7d673dfdf25d
-https://github.com/Googulator/nyacc/releases/download/V1.00.2-lb1/nyacc-1.00.2-lb1.tar.gz 708c943f89c972910e9544ee077771acbd0a2c0fc6d33496fe158264ddb65327
-https://archive.org/download/live-bootstrap-sources/nyacc-1.00.2-lb1.tar.gz 708c943f89c972910e9544ee077771acbd0a2c0fc6d33496fe158264ddb65327
-https://files.bootstrapping.world/nyacc-1.00.2-lb1.tar.gz 708c943f89c972910e9544ee077771acbd0a2c0fc6d33496fe158264ddb65327
+f https://mirrors.kernel.org/gnu/mes/mes-0.27.1.tar.gz 183a40ea47ea49f8a1e3bd1b9d12e676374d64d63bc79e7bc1ae7d673dfdf25d
+f https://github.com/Googulator/nyacc/releases/download/V1.00.2-lb1/nyacc-1.00.2-lb1.tar.gz 708c943f89c972910e9544ee077771acbd0a2c0fc6d33496fe158264ddb65327
+f https://archive.org/download/live-bootstrap-sources/nyacc-1.00.2-lb1.tar.gz 708c943f89c972910e9544ee077771acbd0a2c0fc6d33496fe158264ddb65327
+f https://files.bootstrapping.world/nyacc-1.00.2-lb1.tar.gz 708c943f89c972910e9544ee077771acbd0a2c0fc6d33496fe158264ddb65327

--- a/steps/mpc-1.2.1/sources
+++ b/steps/mpc-1.2.1/sources
@@ -1,1 +1,1 @@
-http://mirrors.kernel.org/gnu/mpc/mpc-1.2.1.tar.gz 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459
+f http://mirrors.kernel.org/gnu/mpc/mpc-1.2.1.tar.gz 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459

--- a/steps/mpfr-4.1.0/sources
+++ b/steps/mpfr-4.1.0/sources
@@ -1,1 +1,1 @@
-http://mirrors.kernel.org/gnu/mpfr/mpfr-4.1.0.tar.xz 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
+f http://mirrors.kernel.org/gnu/mpfr/mpfr-4.1.0.tar.xz 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f

--- a/steps/musl-1.1.24/sources
+++ b/steps/musl-1.1.24/sources
@@ -1,1 +1,1 @@
-https://musl.libc.org/releases/musl-1.1.24.tar.gz 1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
+f https://musl.libc.org/releases/musl-1.1.24.tar.gz 1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3

--- a/steps/musl-1.2.5/sources
+++ b/steps/musl-1.2.5/sources
@@ -1,1 +1,1 @@
-https://musl.libc.org/releases/musl-1.2.5.tar.gz a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4
+f https://musl.libc.org/releases/musl-1.2.5.tar.gz a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4

--- a/steps/opendoas-6.8.2/sources
+++ b/steps/opendoas-6.8.2/sources
@@ -1,1 +1,1 @@
-https://github.com/Duncaen/OpenDoas/releases/download/v6.8.2/opendoas-6.8.2.tar.xz 4e98828056d6266bd8f2c93e6ecf12a63a71dbfd70a5ea99ccd4ab6d0745adf0
+f https://github.com/Duncaen/OpenDoas/releases/download/v6.8.2/opendoas-6.8.2.tar.xz 4e98828056d6266bd8f2c93e6ecf12a63a71dbfd70a5ea99ccd4ab6d0745adf0

--- a/steps/openssl-3.0.13/sources
+++ b/steps/openssl-3.0.13/sources
@@ -1,1 +1,1 @@
-https://github.com/openssl/openssl/releases/download/openssl-3.0.13/openssl-3.0.13.tar.gz 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
+f https://github.com/openssl/openssl/releases/download/openssl-3.0.13/openssl-3.0.13.tar.gz 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313

--- a/steps/oyacc-6.6/sources
+++ b/steps/oyacc-6.6/sources
@@ -1,1 +1,1 @@
-https://github.com/ibara/yacc/releases/download/oyacc-6.6/oyacc-6.6.tar.gz eb0866e740b79bd3a23e0ca47885eb3148aab18d77a4bedba96e979d8b4ebfe1
+f https://github.com/ibara/yacc/releases/download/oyacc-6.6/oyacc-6.6.tar.gz eb0866e740b79bd3a23e0ca47885eb3148aab18d77a4bedba96e979d8b4ebfe1

--- a/steps/patch-2.5.9/sources
+++ b/steps/patch-2.5.9/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/patch/patch-2.5.9.tar.gz ecb5c6469d732bcf01d6ec1afe9e64f1668caba5bfdb103c28d7f537ba3cdb8a
+f https://mirrors.kernel.org/gnu/patch/patch-2.5.9.tar.gz ecb5c6469d732bcf01d6ec1afe9e64f1668caba5bfdb103c28d7f537ba3cdb8a

--- a/steps/patch-2.7.6/sources
+++ b/steps/patch-2.7.6/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/patch/patch-2.7.6.tar.xz ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd
-git://git.savannah.gnu.org/gnulib.git~e017871 _ a285dc300c3d9c25cc06e38827ef40f6073ec3b9b0fcb5bba433f943be92d8d4 gnulib-e017871.tar.gz
+f https://mirrors.kernel.org/gnu/patch/patch-2.7.6.tar.xz ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd
+g git://git.savannah.gnu.org/gnulib.git~e017871 _ a285dc300c3d9c25cc06e38827ef40f6073ec3b9b0fcb5bba433f943be92d8d4 gnulib-e017871.tar.gz

--- a/steps/patch-2.7.6/sources
+++ b/steps/patch-2.7.6/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/patch/patch-2.7.6.tar.xz ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd
-g git://git.savannah.gnu.org/gnulib.git~e017871 _ a285dc300c3d9c25cc06e38827ef40f6073ec3b9b0fcb5bba433f943be92d8d4 gnulib-e017871.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~e017871 _ a285dc300c3d9c25cc06e38827ef40f6073ec3b9b0fcb5bba433f943be92d8d4 gnulib-e017871.tar.gz

--- a/steps/perl-5.000/sources
+++ b/steps/perl-5.000/sources
@@ -1,1 +1,1 @@
-https://github.com/Perl/perl5/archive/perl-5.000.tar.gz 1ae43c8d2983404b9eec61c96e3ffa27e7b07e08215c95c015a4ab0095373ef3
+f https://github.com/Perl/perl5/archive/perl-5.000.tar.gz 1ae43c8d2983404b9eec61c96e3ffa27e7b07e08215c95c015a4ab0095373ef3

--- a/steps/perl-5.003/sources
+++ b/steps/perl-5.003/sources
@@ -1,1 +1,1 @@
-https://github.com/Perl/perl5/archive/perl-5.003.tar.gz 9fa29beb2fc4a3c373829fc051830796de301f32a719d0b52a400d1719bbd7b1
+f https://github.com/Perl/perl5/archive/perl-5.003.tar.gz 9fa29beb2fc4a3c373829fc051830796de301f32a719d0b52a400d1719bbd7b1

--- a/steps/perl-5.10.1/sources
+++ b/steps/perl-5.10.1/sources
@@ -1,1 +1,1 @@
-http://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826
+f http://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826

--- a/steps/perl-5.32.1/sources
+++ b/steps/perl-5.32.1/sources
@@ -1,2 +1,2 @@
 f http://www.cpan.org/src/5.0/perl-5.32.1.tar.xz 57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309
-g git://github.com/Perl/metaconfig~5.32.1 https://github.com/Perl/metaconfig/archive/refs/tags/5.32.1.tar.gz 23abd0d49995229426775c7b1a973e0722faf99bc52e5030d188f0f37973e841
+g https://github.com/Perl/metaconfig~5.32.1 https://github.com/Perl/metaconfig/archive/refs/tags/5.32.1.tar.gz 23abd0d49995229426775c7b1a973e0722faf99bc52e5030d188f0f37973e841

--- a/steps/perl-5.32.1/sources
+++ b/steps/perl-5.32.1/sources
@@ -1,2 +1,2 @@
-http://www.cpan.org/src/5.0/perl-5.32.1.tar.xz 57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309
-git://github.com/Perl/metaconfig~5.32.1 https://github.com/Perl/metaconfig/archive/refs/tags/5.32.1.tar.gz 23abd0d49995229426775c7b1a973e0722faf99bc52e5030d188f0f37973e841
+f http://www.cpan.org/src/5.0/perl-5.32.1.tar.xz 57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309
+g git://github.com/Perl/metaconfig~5.32.1 https://github.com/Perl/metaconfig/archive/refs/tags/5.32.1.tar.gz 23abd0d49995229426775c7b1a973e0722faf99bc52e5030d188f0f37973e841

--- a/steps/perl-5.6.2/sources
+++ b/steps/perl-5.6.2/sources
@@ -1,1 +1,1 @@
-https://www.cpan.org/src/5.0/perl-5.6.2.tar.gz a5e66f6ebf701b0567f569f57cae82abf5ce57af70a2b45ae71323b61f49134e
+f https://www.cpan.org/src/5.0/perl-5.6.2.tar.gz a5e66f6ebf701b0567f569f57cae82abf5ce57af70a2b45ae71323b61f49134e

--- a/steps/perl5.004-05/sources
+++ b/steps/perl5.004-05/sources
@@ -1,1 +1,1 @@
-https://www.cpan.org/src/5.0/perl5.004_05.tar.gz 1184478b298978b164a383ed5661e3a117c48ab97d6d0ab7ef614cdbe918b9eb 
+f https://www.cpan.org/src/5.0/perl5.004_05.tar.gz 1184478b298978b164a383ed5661e3a117c48ab97d6d0ab7ef614cdbe918b9eb 

--- a/steps/perl5.005-03/sources
+++ b/steps/perl5.005-03/sources
@@ -1,1 +1,1 @@
-https://www.cpan.org/src/5.0/perl5.005_03.tar.gz 93f41cd87ab8ee83391cfa39a63b076adeb7c3501d2efa31b98d0ef037122bd1
+f https://www.cpan.org/src/5.0/perl5.005_03.tar.gz 93f41cd87ab8ee83391cfa39a63b076adeb7c3501d2efa31b98d0ef037122bd1

--- a/steps/pkg-config-0.29.2/sources
+++ b/steps/pkg-config-0.29.2/sources
@@ -1,7 +1,7 @@
-https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz 6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
-http://ftp.unicode.org/Public/6.2.0/ucd/UnicodeData.txt 8b2cd18247527aa08ec320c3352b6a01b95d63199f20b3b593ea5d5217bdd170 UnicodeData-6.2.0.txt
-http://ftp.unicode.org/Public/6.2.0/ucd/LineBreak.txt 5e2eb009b078569e7954789b2d7b5c026b0b40be6fb9400c6e1ecc7d13f4a13f LineBreak-6.2.0.txt
-http://ftp.unicode.org/Public/6.2.0/ucd/SpecialCasing.txt 707209a69d7f760e3cc461ce26d789f83d6fb694336c83b14652cd44413aa334 SpecialCasing-6.2.0.txt
-http://ftp.unicode.org/Public/6.2.0/ucd/CaseFolding.txt 5cbd9afdddd91fee53871c9b36a34899b0a5bcdf4569ca1a3c98cae3ec3d6333 CaseFolding-6.2.0.txt
-http://ftp.unicode.org/Public/6.2.0/ucd/CompositionExclusions.txt 3b3f5051bd74e21df7f2b1b264ead48be626cdeefb061c04ce7280a2358efff9 CompositionExclusions-6.2.0.txt
-http://ftp.unicode.org/Public/6.2.0/ucd/Scripts.txt 4cdeb69b6bfead1c170a81b544e7488549575493715ab632bd7492bc92c4823e Scripts-6.2.0.txt
+f https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz 6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
+f http://ftp.unicode.org/Public/6.2.0/ucd/UnicodeData.txt 8b2cd18247527aa08ec320c3352b6a01b95d63199f20b3b593ea5d5217bdd170 UnicodeData-6.2.0.txt
+f http://ftp.unicode.org/Public/6.2.0/ucd/LineBreak.txt 5e2eb009b078569e7954789b2d7b5c026b0b40be6fb9400c6e1ecc7d13f4a13f LineBreak-6.2.0.txt
+f http://ftp.unicode.org/Public/6.2.0/ucd/SpecialCasing.txt 707209a69d7f760e3cc461ce26d789f83d6fb694336c83b14652cd44413aa334 SpecialCasing-6.2.0.txt
+f http://ftp.unicode.org/Public/6.2.0/ucd/CaseFolding.txt 5cbd9afdddd91fee53871c9b36a34899b0a5bcdf4569ca1a3c98cae3ec3d6333 CaseFolding-6.2.0.txt
+f http://ftp.unicode.org/Public/6.2.0/ucd/CompositionExclusions.txt 3b3f5051bd74e21df7f2b1b264ead48be626cdeefb061c04ce7280a2358efff9 CompositionExclusions-6.2.0.txt
+f http://ftp.unicode.org/Public/6.2.0/ucd/Scripts.txt 4cdeb69b6bfead1c170a81b544e7488549575493715ab632bd7492bc92c4823e Scripts-6.2.0.txt

--- a/steps/python-2.0.1/sources
+++ b/steps/python-2.0.1/sources
@@ -1,2 +1,2 @@
-https://www.python.org/ftp/python/2.0.1/Python-2.0.1.tgz 98557b819a42d2093b41d8637302d1311b81f627af9ad20036357d7eb2813872
-http://ftp.unicode.org/Public/3.0-Update/UnicodeData-3.0.0.txt f41d967bc458ee106f0c3948bfad71cd0860d96c49304e3fd02eaf2bbae4b6d9
+f https://www.python.org/ftp/python/2.0.1/Python-2.0.1.tgz 98557b819a42d2093b41d8637302d1311b81f627af9ad20036357d7eb2813872
+f http://ftp.unicode.org/Public/3.0-Update/UnicodeData-3.0.0.txt f41d967bc458ee106f0c3948bfad71cd0860d96c49304e3fd02eaf2bbae4b6d9

--- a/steps/python-2.3.7/sources
+++ b/steps/python-2.3.7/sources
@@ -1,3 +1,3 @@
-https://www.python.org/ftp/python/2.3.7/Python-2.3.7.tgz 969a9891dce9f50b13e54f9890acaf2be66715a5895bf9b11111f320c205b90e
-http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
-http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
+f https://www.python.org/ftp/python/2.3.7/Python-2.3.7.tgz 969a9891dce9f50b13e54f9890acaf2be66715a5895bf9b11111f320c205b90e
+f http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
+f http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb

--- a/steps/python-2.5.6/sources
+++ b/steps/python-2.5.6/sources
@@ -1,7 +1,7 @@
-https://www.python.org/ftp/python/2.5.6/Python-2.5.6.tar.bz2 57e04484de051decd4741fb4a4a3f543becc9a219af8b8063b5541e270f26dcc
-http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
-http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
-http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
-http://ftp.unicode.org/Public/4.1.0/ucd/UnicodeData.txt a9f03f6a061ee210c53e33782288a208bed48c65c70d307b2b214989cedfdab0 UnicodeData-4.1.0.txt
-http://ftp.unicode.org/Public/4.1.0/ucd/CompositionExclusions.txt 1003a6896078e77532a017b135762501ff0a540ba33694e32b6177f093ebe6b2 CompositionExclusions-4.1.0.txt
-http://ftp.unicode.org/Public/4.1.0/ucd/EastAsianWidth.txt 089ed5b2becd3196e61124d36e968474d3b7152cb5a3fb56594c34ab1e698e92 EastAsianWidth-4.1.0.txt
+f https://www.python.org/ftp/python/2.5.6/Python-2.5.6.tar.bz2 57e04484de051decd4741fb4a4a3f543becc9a219af8b8063b5541e270f26dcc
+f http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
+f http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
+f http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
+f http://ftp.unicode.org/Public/4.1.0/ucd/UnicodeData.txt a9f03f6a061ee210c53e33782288a208bed48c65c70d307b2b214989cedfdab0 UnicodeData-4.1.0.txt
+f http://ftp.unicode.org/Public/4.1.0/ucd/CompositionExclusions.txt 1003a6896078e77532a017b135762501ff0a540ba33694e32b6177f093ebe6b2 CompositionExclusions-4.1.0.txt
+f http://ftp.unicode.org/Public/4.1.0/ucd/EastAsianWidth.txt 089ed5b2becd3196e61124d36e968474d3b7152cb5a3fb56594c34ab1e698e92 EastAsianWidth-4.1.0.txt

--- a/steps/python-3.1.5/sources
+++ b/steps/python-3.1.5/sources
@@ -1,12 +1,12 @@
-https://www.python.org/ftp/python/3.1.5/Python-3.1.5.tar.bz2 3a72a21528f0751e89151744350dd12004131d312d47b935ce8041b070c90361
-http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
-http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
-http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
-http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
-http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
-http://ftp.unicode.org/Public/5.1.0/ucd/UnicodeData.txt 8bd83e9c4e339728ecd532c5b174de5beb9cb4bab5db14e44fcd03ccb2e2c1b5 UnicodeData-5.1.0.txt
-http://ftp.unicode.org/Public/5.1.0/ucd/CompositionExclusions.txt 683b094f2bdd0ab132c0bac293a5404626dd858a53b5364b3b6b525323c5a5e4 CompositionExclusions-5.1.0.txt
-http://ftp.unicode.org/Public/5.1.0/ucd/EastAsianWidth.txt a0d8abf08d08f3e61875aed6011cb70c61dd8ea61089e6ad9b6cf524d8fba0f2 EastAsianWidth-5.1.0.txt
-http://ftp.unicode.org/Public/5.1.0/ucd/DerivedCoreProperties.txt 8f54c77587fee99facc2f28b94e748dfdda5da44f42adab31a65f88b63587ae0 DerivedCoreProperties-5.1.0.txt
-http://ftp.unicode.org/Public/5.1.0/ucd/DerivedNormalizationProps.txt 4fc8cbfa1eed578cdda0768fb4a4ace5443f807c1f652e36a6bd768e81c2c2a3 DerivedNormalizationProps-5.1.0.txt
-http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac
+f https://www.python.org/ftp/python/3.1.5/Python-3.1.5.tar.bz2 3a72a21528f0751e89151744350dd12004131d312d47b935ce8041b070c90361
+f http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
+f http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
+f http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
+f http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
+f http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
+f http://ftp.unicode.org/Public/5.1.0/ucd/UnicodeData.txt 8bd83e9c4e339728ecd532c5b174de5beb9cb4bab5db14e44fcd03ccb2e2c1b5 UnicodeData-5.1.0.txt
+f http://ftp.unicode.org/Public/5.1.0/ucd/CompositionExclusions.txt 683b094f2bdd0ab132c0bac293a5404626dd858a53b5364b3b6b525323c5a5e4 CompositionExclusions-5.1.0.txt
+f http://ftp.unicode.org/Public/5.1.0/ucd/EastAsianWidth.txt a0d8abf08d08f3e61875aed6011cb70c61dd8ea61089e6ad9b6cf524d8fba0f2 EastAsianWidth-5.1.0.txt
+f http://ftp.unicode.org/Public/5.1.0/ucd/DerivedCoreProperties.txt 8f54c77587fee99facc2f28b94e748dfdda5da44f42adab31a65f88b63587ae0 DerivedCoreProperties-5.1.0.txt
+f http://ftp.unicode.org/Public/5.1.0/ucd/DerivedNormalizationProps.txt 4fc8cbfa1eed578cdda0768fb4a4ace5443f807c1f652e36a6bd768e81c2c2a3 DerivedNormalizationProps-5.1.0.txt
+f http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac

--- a/steps/python-3.11.1/sources
+++ b/steps/python-3.11.1/sources
@@ -1,24 +1,24 @@
-https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tar.xz 85879192f2cffd56cb16c092905949ebf3e5e394b7f764723529637901dfb58f
-http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
-http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
-http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
-http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
-http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
-http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
-http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
-http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
-http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
-http://ftp.unicode.org/Public/14.0.0/ucd/UnicodeData.txt 36018e68657fdcb3485f636630ffe8c8532e01c977703d2803f5b89d6c5feafb UnicodeData-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/CompositionExclusions.txt 3360762fc3295cea54ab251c31df621d05ba4b94d46c60eaac29aa16d70ad1e0 CompositionExclusions-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/EastAsianWidth.txt f901ac011aa32a09224d6555da71e2532c59c1d3381322829de0e3b880507250 EastAsianWidth-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/DerivedCoreProperties.txt e3eddd7d469cd1b0feed7528defad1a1cc7c6a9ceb0ae4446a6d10921ed2e7bc DerivedCoreProperties-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/DerivedNormalizationProps.txt b2c444c20730b097787fdf50bd7d6dd3fc5256ab8084f5b35b11c8776eca674c DerivedNormalizationProps-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/LineBreak.txt 9e06e9f35c6959fb91dcc7993f90d58523c3079bc62c6b25f828b4cdebc5d70c LineBreak-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/NameAliases.txt 14b3b677d33f95c51423dce6eef4a6a28b4b160451ecedee4b91edb6745cf4a3 NameAliases-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/NamedSequences.txt db5745688affcdc0c3927a1ee0667018a96a7b24513f866d5235e98fef6c2436 NamedSequences-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/SpecialCasing.txt c667b45908fd269af25fd55d2fc5bbc157fb1b77675936e25c513ce32e080334 SpecialCasing-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/CaseFolding.txt a566cd48687b2cd897e02501118b2413c14ae86d318f9abbbba97feb84189f0f CaseFolding-14.0.0.txt
-http://ftp.unicode.org/Public/14.0.0/ucd/Unihan.zip 2ae4519b2b82cd4d15379c17e57bfb12c33c0f54da4977de03b2b04bcf11852d Unihan-14.0.0.zip
-http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac
-https://www.ietf.org/rfc/rfc3454.txt eb722fa698fb7e8823b835d9fd263e4cdb8f1c7b0d234edf7f0e3bd2ccbb2c79
-https://github.com/openssl/openssl/releases/download/openssl-3.0.13/openssl-3.0.13.tar.gz 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
+f https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tar.xz 85879192f2cffd56cb16c092905949ebf3e5e394b7f764723529637901dfb58f
+f http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
+f http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
+f http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
+f http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
+f http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
+f http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
+f http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
+f http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
+f http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
+f http://ftp.unicode.org/Public/14.0.0/ucd/UnicodeData.txt 36018e68657fdcb3485f636630ffe8c8532e01c977703d2803f5b89d6c5feafb UnicodeData-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/CompositionExclusions.txt 3360762fc3295cea54ab251c31df621d05ba4b94d46c60eaac29aa16d70ad1e0 CompositionExclusions-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/EastAsianWidth.txt f901ac011aa32a09224d6555da71e2532c59c1d3381322829de0e3b880507250 EastAsianWidth-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/DerivedCoreProperties.txt e3eddd7d469cd1b0feed7528defad1a1cc7c6a9ceb0ae4446a6d10921ed2e7bc DerivedCoreProperties-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/DerivedNormalizationProps.txt b2c444c20730b097787fdf50bd7d6dd3fc5256ab8084f5b35b11c8776eca674c DerivedNormalizationProps-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/LineBreak.txt 9e06e9f35c6959fb91dcc7993f90d58523c3079bc62c6b25f828b4cdebc5d70c LineBreak-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/NameAliases.txt 14b3b677d33f95c51423dce6eef4a6a28b4b160451ecedee4b91edb6745cf4a3 NameAliases-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/NamedSequences.txt db5745688affcdc0c3927a1ee0667018a96a7b24513f866d5235e98fef6c2436 NamedSequences-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/SpecialCasing.txt c667b45908fd269af25fd55d2fc5bbc157fb1b77675936e25c513ce32e080334 SpecialCasing-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/CaseFolding.txt a566cd48687b2cd897e02501118b2413c14ae86d318f9abbbba97feb84189f0f CaseFolding-14.0.0.txt
+f http://ftp.unicode.org/Public/14.0.0/ucd/Unihan.zip 2ae4519b2b82cd4d15379c17e57bfb12c33c0f54da4977de03b2b04bcf11852d Unihan-14.0.0.zip
+f http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac
+f https://www.ietf.org/rfc/rfc3454.txt eb722fa698fb7e8823b835d9fd263e4cdb8f1c7b0d234edf7f0e3bd2ccbb2c79
+f https://github.com/openssl/openssl/releases/download/openssl-3.0.13/openssl-3.0.13.tar.gz 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313

--- a/steps/python-3.3.7/sources
+++ b/steps/python-3.3.7/sources
@@ -1,22 +1,22 @@
-https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tar.xz 85f60c327501c36bc18c33370c14d472801e6af2f901dafbba056f61685429fe
-http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
-http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
-http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
-http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
-http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
-http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
-http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
-http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
-http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
-http://ftp.unicode.org/Public/6.1.0/ucd/UnicodeData.txt 3066262585a3c4f407b16db787e6d3a6e033b90f27405b6c76d1babefffca6ad UnicodeData-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/CompositionExclusions.txt 21124f9d38372d68e09c67bcb64694fd4bca0c9cb39c576b1f095554c4ea9693 CompositionExclusions-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/EastAsianWidth.txt d591c24b702c1b025b58ca6168746f713b657c6e252c268f52cb07758f428067 EastAsianWidth-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/DerivedCoreProperties.txt a03e62ba5fa9c6f327b6e6cfc5d014f59af9b262b768dd9a6aaa39d205dd8b7a DerivedCoreProperties-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/DerivedNormalizationProps.txt d028f7eccab4998f8d7a6b15703b088e26ff6ee1f2dbc0939ae872c213de8620 DerivedNormalizationProps-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/LineBreak.txt 7b7e2cf582ef7f24fd2747a4ef1a50934c15a0fc0ab10ce737d5e3e47bebde0d LineBreak-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/NameAliases.txt 7253bd84e20d34491b2b124a85ca84bd2cd5d113e4957aebae92f0e3c21f0a45 NameAliases-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/NamedSequences.txt 60c88b6e3ceec871cc6b7e2d552453f88eef0f40ff2188d9cec7021c2debd36a NamedSequences-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/SpecialCasing.txt 7d047fe1aa8a68cc12101427cf03bfbce83201ee277e907822901735f0bfee3c SpecialCasing-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/CaseFolding.txt 4c0bece13821a24f469bb8d16ea33fc7da6436b7ebe64c78635673dbfaa88edc CaseFolding-6.1.0.txt
-http://ftp.unicode.org/Public/6.1.0/ucd/Unihan.zip 8ca508ef1bc7eba8c102710016d8510f871f69bdcc74ff877c33d01bb799a38f Unihan-6.1.0.zip
-http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac
+f https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tar.xz 85f60c327501c36bc18c33370c14d472801e6af2f901dafbba056f61685429fe
+f http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
+f http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
+f http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
+f http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
+f http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
+f http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
+f http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
+f http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
+f http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
+f http://ftp.unicode.org/Public/6.1.0/ucd/UnicodeData.txt 3066262585a3c4f407b16db787e6d3a6e033b90f27405b6c76d1babefffca6ad UnicodeData-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/CompositionExclusions.txt 21124f9d38372d68e09c67bcb64694fd4bca0c9cb39c576b1f095554c4ea9693 CompositionExclusions-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/EastAsianWidth.txt d591c24b702c1b025b58ca6168746f713b657c6e252c268f52cb07758f428067 EastAsianWidth-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/DerivedCoreProperties.txt a03e62ba5fa9c6f327b6e6cfc5d014f59af9b262b768dd9a6aaa39d205dd8b7a DerivedCoreProperties-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/DerivedNormalizationProps.txt d028f7eccab4998f8d7a6b15703b088e26ff6ee1f2dbc0939ae872c213de8620 DerivedNormalizationProps-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/LineBreak.txt 7b7e2cf582ef7f24fd2747a4ef1a50934c15a0fc0ab10ce737d5e3e47bebde0d LineBreak-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/NameAliases.txt 7253bd84e20d34491b2b124a85ca84bd2cd5d113e4957aebae92f0e3c21f0a45 NameAliases-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/NamedSequences.txt 60c88b6e3ceec871cc6b7e2d552453f88eef0f40ff2188d9cec7021c2debd36a NamedSequences-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/SpecialCasing.txt 7d047fe1aa8a68cc12101427cf03bfbce83201ee277e907822901735f0bfee3c SpecialCasing-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/CaseFolding.txt 4c0bece13821a24f469bb8d16ea33fc7da6436b7ebe64c78635673dbfaa88edc CaseFolding-6.1.0.txt
+f http://ftp.unicode.org/Public/6.1.0/ucd/Unihan.zip 8ca508ef1bc7eba8c102710016d8510f871f69bdcc74ff877c33d01bb799a38f Unihan-6.1.0.zip
+f http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac

--- a/steps/python-3.4.10/sources
+++ b/steps/python-3.4.10/sources
@@ -1,22 +1,22 @@
-https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tar.xz d46a8f6fe91679e199c671b1b0a30aaf172d2acb5bcab25beb35f16c3d195b4e
-http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
-http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
-http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
-http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
-http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
-http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
-http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
-http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
-http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
-http://ftp.unicode.org/Public/6.3.0/ucd/UnicodeData.txt 3f76924f0410ca8ae0e9b5c59bd1ba03196293c32616204b393300f091f52013 UnicodeData-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/CompositionExclusions.txt 4ba8ea079ffbffc0025fc31009e95726864feda90d2845c9363c0c40ded8511c CompositionExclusions-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/EastAsianWidth.txt bbdf9281767ca4601af3623b62c26ecb834a9f4c46eec629d82339b006da00d8 EastAsianWidth-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/DerivedCoreProperties.txt 790826f4cfa82c5845ab4040b5e811f1e67bf1ec4c88cdbf722795c3292b0102 DerivedCoreProperties-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/DerivedNormalizationProps.txt c5e867ae043fe5d1cf713150d859356bfdcdba291c39f584af0bfb943f1a9743 DerivedNormalizationProps-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/LineBreak.txt 6a38069025127a60f4a809e788fbbd1bb6b95ac8d1bd62e6a78d7870357f3486 LineBreak-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/NameAliases.txt a11bed87ec6f264edcf84d581dd2d7ac8ed7ac1c3b2ccb54a83077fdbd34133e NameAliases-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/NamedSequences.txt 91fc69ff68b1a89e5f7270545547c747624bc96b0e6c23a791d4265d2fa1f988 NamedSequences-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/SpecialCasing.txt 9edafba261e23e72f6e21e3d85d7f15dd4866f38004ab3bfdc6f7057c589d034 SpecialCasing-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/CaseFolding.txt 21323e682a2b34400c6af4ab57b9775b7e716150428f092bac5b005a88ab8f42 CaseFolding-6.3.0.txt
-http://ftp.unicode.org/Public/6.3.0/ucd/Unihan.zip 9e408d71e3aba4ff68f5085569bc1c31c9751f9779f55cf877c222467732991f Unihan-6.3.0.zip
-http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac
+f https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tar.xz d46a8f6fe91679e199c671b1b0a30aaf172d2acb5bcab25beb35f16c3d195b4e
+f http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
+f http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
+f http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
+f http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
+f http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
+f http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
+f http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
+f http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
+f http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
+f http://ftp.unicode.org/Public/6.3.0/ucd/UnicodeData.txt 3f76924f0410ca8ae0e9b5c59bd1ba03196293c32616204b393300f091f52013 UnicodeData-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/CompositionExclusions.txt 4ba8ea079ffbffc0025fc31009e95726864feda90d2845c9363c0c40ded8511c CompositionExclusions-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/EastAsianWidth.txt bbdf9281767ca4601af3623b62c26ecb834a9f4c46eec629d82339b006da00d8 EastAsianWidth-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/DerivedCoreProperties.txt 790826f4cfa82c5845ab4040b5e811f1e67bf1ec4c88cdbf722795c3292b0102 DerivedCoreProperties-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/DerivedNormalizationProps.txt c5e867ae043fe5d1cf713150d859356bfdcdba291c39f584af0bfb943f1a9743 DerivedNormalizationProps-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/LineBreak.txt 6a38069025127a60f4a809e788fbbd1bb6b95ac8d1bd62e6a78d7870357f3486 LineBreak-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/NameAliases.txt a11bed87ec6f264edcf84d581dd2d7ac8ed7ac1c3b2ccb54a83077fdbd34133e NameAliases-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/NamedSequences.txt 91fc69ff68b1a89e5f7270545547c747624bc96b0e6c23a791d4265d2fa1f988 NamedSequences-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/SpecialCasing.txt 9edafba261e23e72f6e21e3d85d7f15dd4866f38004ab3bfdc6f7057c589d034 SpecialCasing-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/CaseFolding.txt 21323e682a2b34400c6af4ab57b9775b7e716150428f092bac5b005a88ab8f42 CaseFolding-6.3.0.txt
+f http://ftp.unicode.org/Public/6.3.0/ucd/Unihan.zip 9e408d71e3aba4ff68f5085569bc1c31c9751f9779f55cf877c222467732991f Unihan-6.3.0.zip
+f http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac

--- a/steps/python-3.8.16/sources
+++ b/steps/python-3.8.16/sources
@@ -1,23 +1,23 @@
-https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz d85dbb3774132473d8081dcb158f34a10ccad7a90b96c7e50ea4bb61f5ce4562
-http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
-http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
-http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
-http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
-http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
-http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
-http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
-http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
-http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
-http://ftp.unicode.org/Public/12.1.0/ucd/UnicodeData.txt 93ab1acd8fd9d450463b50ae77eab151a7cda48f98b25b56baed8070f80fc936 UnicodeData-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/CompositionExclusions.txt abc8394c5bde62453118b00c1c5842160a04d7fffb2e829ee5426b846596d081 CompositionExclusions-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/EastAsianWidth.txt 904500178b2e752635bef27aaed3a2a3718a100bce35ff96b3890be7a8315d8f EastAsianWidth-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/DerivedCoreProperties.txt a6eb7a8671fb532fbd88c37fd7b20b5b2e7dbfc8b121f74c14abe2947db0da68 DerivedCoreProperties-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/DerivedNormalizationProps.txt 92dcdda84142194a1596f22180fcdf8c0e7f86897f09cc9203c7dc636c549f5f DerivedNormalizationProps-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/LineBreak.txt 961f842fc70b5afd1d82c6645e68c10d1f701382aed38ae38cb2ff27f671903c LineBreak-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/NameAliases.txt ff61a0687d2f32c0dd1094254b8bde967883b43c2d4d50fd17531d498e41ab2c NameAliases-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/NamedSequences.txt d3eb9a288ebeaf9de1237989f490705e287b6f610b59d2459fb1b7c2d8e39c39 NamedSequences-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/SpecialCasing.txt 817ce2e9edca8e075a153f54b8f3b020345e37652cd2bda9b1495c366af17e7e SpecialCasing-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/CaseFolding.txt 9c772627c6ee77eea6a17b42927b8ee28ca05dc65d6a511062104baaf3d12294 CaseFolding-12.1.0.txt
-http://ftp.unicode.org/Public/12.1.0/ucd/Unihan.zip 6e4553f3b5fffe0d312df324d020ef1278d9595932ae03f4e8a2d427de83cdcd Unihan-12.1.0.zip
-http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac
-https://www.ietf.org/rfc/rfc3454.txt eb722fa698fb7e8823b835d9fd263e4cdb8f1c7b0d234edf7f0e3bd2ccbb2c79
+f https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz d85dbb3774132473d8081dcb158f34a10ccad7a90b96c7e50ea4bb61f5ce4562
+f http://ftp.unicode.org/Public/3.2-Update/UnicodeData-3.2.0.txt 5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446
+f http://ftp.unicode.org/Public/3.2-Update/CompositionExclusions-3.2.0.txt 1d3a450d0f39902710df4972ac4a60ec31fbcb54ffd4d53cd812fc1200c732cb
+f http://ftp.unicode.org/Public/3.2-Update/EastAsianWidth-3.2.0.txt ce19f35ffca911bf492aab6c0d3f6af3d1932f35d2064cf2fe14e10be29534cb
+f http://ftp.unicode.org/Public/3.2-Update/DerivedCoreProperties-3.2.0.txt 787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c
+f http://ftp.unicode.org/Public/3.2-Update/DerivedNormalizationProps-3.2.0.txt bab49295e5f9064213762447224ccd83cea0cced0db5dcfc96f9c8a935ef67ee
+f http://ftp.unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735
+f http://ftp.unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt 1f7913b74dddff55ee566f6220aa9e465bae6f27709fc21d353b04adb8572b37
+f http://ftp.unicode.org/Public/3.2-Update/CaseFolding-3.2.0.txt 370f3d1e79a52791c42065946711f4eddb6d9820726afd0e436a3c50360475a9
+f http://ftp.unicode.org/Public/3.2-Update/Unihan-3.2.0.zip 0582b888c4ebab6e3ce8d340c74788f1a68ca662713a1065b9a007f24bb4fe46
+f http://ftp.unicode.org/Public/12.1.0/ucd/UnicodeData.txt 93ab1acd8fd9d450463b50ae77eab151a7cda48f98b25b56baed8070f80fc936 UnicodeData-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/CompositionExclusions.txt abc8394c5bde62453118b00c1c5842160a04d7fffb2e829ee5426b846596d081 CompositionExclusions-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/EastAsianWidth.txt 904500178b2e752635bef27aaed3a2a3718a100bce35ff96b3890be7a8315d8f EastAsianWidth-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/DerivedCoreProperties.txt a6eb7a8671fb532fbd88c37fd7b20b5b2e7dbfc8b121f74c14abe2947db0da68 DerivedCoreProperties-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/DerivedNormalizationProps.txt 92dcdda84142194a1596f22180fcdf8c0e7f86897f09cc9203c7dc636c549f5f DerivedNormalizationProps-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/LineBreak.txt 961f842fc70b5afd1d82c6645e68c10d1f701382aed38ae38cb2ff27f671903c LineBreak-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/NameAliases.txt ff61a0687d2f32c0dd1094254b8bde967883b43c2d4d50fd17531d498e41ab2c NameAliases-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/NamedSequences.txt d3eb9a288ebeaf9de1237989f490705e287b6f610b59d2459fb1b7c2d8e39c39 NamedSequences-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/SpecialCasing.txt 817ce2e9edca8e075a153f54b8f3b020345e37652cd2bda9b1495c366af17e7e SpecialCasing-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/CaseFolding.txt 9c772627c6ee77eea6a17b42927b8ee28ca05dc65d6a511062104baaf3d12294 CaseFolding-12.1.0.txt
+f http://ftp.unicode.org/Public/12.1.0/ucd/Unihan.zip 6e4553f3b5fffe0d312df324d020ef1278d9595932ae03f4e8a2d427de83cdcd Unihan-12.1.0.zip
+f http://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP437.TXT 6bad4dabcdf5940227c7d81fab130dcb18a77850b5d79de28b5dc4e047b0aaac
+f https://www.ietf.org/rfc/rfc3454.txt eb722fa698fb7e8823b835d9fd263e4cdb8f1c7b0d234edf7f0e3bd2ccbb2c79

--- a/steps/sed-4.0.9/sources
+++ b/steps/sed-4.0.9/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/sed/sed-4.0.9.tar.gz c365874794187f8444e5d22998cd5888ffa47f36def4b77517a808dec27c0600
+f https://mirrors.kernel.org/gnu/sed/sed-4.0.9.tar.gz c365874794187f8444e5d22998cd5888ffa47f36def4b77517a808dec27c0600

--- a/steps/sed-4.8/sources
+++ b/steps/sed-4.8/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/sed/sed-4.8.tar.xz f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633
-git://git.savannah.gnu.org/gnulib.git~d279bc _ 12cfa21abf618a274017d6b18e95fc6582519d7c08e2403e5c5772ccdd5b85f4 gnulib-d279bc.tar.gz
+f https://mirrors.kernel.org/gnu/sed/sed-4.8.tar.xz f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633
+g git://git.savannah.gnu.org/gnulib.git~d279bc _ 12cfa21abf618a274017d6b18e95fc6582519d7c08e2403e5c5772ccdd5b85f4 gnulib-d279bc.tar.gz

--- a/steps/sed-4.8/sources
+++ b/steps/sed-4.8/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/sed/sed-4.8.tar.xz f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633
-g git://git.savannah.gnu.org/gnulib.git~d279bc _ 12cfa21abf618a274017d6b18e95fc6582519d7c08e2403e5c5772ccdd5b85f4 gnulib-d279bc.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~d279bc _ 12cfa21abf618a274017d6b18e95fc6582519d7c08e2403e5c5772ccdd5b85f4 gnulib-d279bc.tar.gz

--- a/steps/shadow-4.14.3/sources
+++ b/steps/shadow-4.14.3/sources
@@ -1,1 +1,1 @@
-https://github.com/shadow-maint/shadow/releases/download/4.14.3/shadow-4.14.3.tar.xz 6969279236fe3152768573a38c9f83cb9ca109851a5a990aec1fc672ac2cfcd2
+f https://github.com/shadow-maint/shadow/releases/download/4.14.3/shadow-4.14.3.tar.xz 6969279236fe3152768573a38c9f83cb9ca109851a5a990aec1fc672ac2cfcd2

--- a/steps/tar-1.12/sources
+++ b/steps/tar-1.12/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/gnu/tar/tar-1.12.tar.gz c6c37e888b136ccefab903c51149f4b7bd659d69d4aea21245f61053a57aa60a
+f https://mirrors.kernel.org/gnu/tar/tar-1.12.tar.gz c6c37e888b136ccefab903c51149f4b7bd659d69d4aea21245f61053a57aa60a

--- a/steps/tar-1.34/sources
+++ b/steps/tar-1.34/sources
@@ -1,2 +1,2 @@
 f http://mirrors.kernel.org/gnu/tar/tar-1.34.tar.xz 63bebd26879c5e1eea4352f0d03c991f966aeb3ddeb3c7445c902568d5411d28
-g git://git.savannah.gnu.org/gnulib.git~30820c _ df807e694deea2dcba0c43af318394f3e3fcd52658c3b71b61dad0ce0c0cfb77 gnulib-30820c.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~30820c _ df807e694deea2dcba0c43af318394f3e3fcd52658c3b71b61dad0ce0c0cfb77 gnulib-30820c.tar.gz

--- a/steps/tar-1.34/sources
+++ b/steps/tar-1.34/sources
@@ -1,2 +1,2 @@
-http://mirrors.kernel.org/gnu/tar/tar-1.34.tar.xz 63bebd26879c5e1eea4352f0d03c991f966aeb3ddeb3c7445c902568d5411d28
-git://git.savannah.gnu.org/gnulib.git~30820c _ df807e694deea2dcba0c43af318394f3e3fcd52658c3b71b61dad0ce0c0cfb77 gnulib-30820c.tar.gz
+f http://mirrors.kernel.org/gnu/tar/tar-1.34.tar.xz 63bebd26879c5e1eea4352f0d03c991f966aeb3ddeb3c7445c902568d5411d28
+g git://git.savannah.gnu.org/gnulib.git~30820c _ df807e694deea2dcba0c43af318394f3e3fcd52658c3b71b61dad0ce0c0cfb77 gnulib-30820c.tar.gz

--- a/steps/tcc-0.9.26/sources
+++ b/steps/tcc-0.9.26/sources
@@ -1,1 +1,1 @@
-https://lilypond.org/janneke/tcc/tcc-0.9.26-1147-gee75a10c.tar.gz 6b8cbd0a5fed0636d4f0f763a603247bc1935e206e1cc5bda6a2818bab6e819f tcc-0.9.26.tar.gz
+f https://lilypond.org/janneke/tcc/tcc-0.9.26-1147-gee75a10c.tar.gz 6b8cbd0a5fed0636d4f0f763a603247bc1935e206e1cc5bda6a2818bab6e819f tcc-0.9.26.tar.gz

--- a/steps/tcc-0.9.27/sources
+++ b/steps/tcc-0.9.27/sources
@@ -1,1 +1,1 @@
-https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27.tar.bz2 de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c
+f https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27.tar.bz2 de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c

--- a/steps/texinfo-6.7/sources
+++ b/steps/texinfo-6.7/sources
@@ -1,2 +1,2 @@
-https://mirrors.kernel.org/gnu/texinfo/texinfo-6.7.tar.xz 988403c1542d15ad044600b909997ba3079b10e03224c61188117f3676b02caa
-git://git.savannah.gnu.org/gnulib.git~b81ec69 _ 1aeea67b7b3883ebcf2b90bc01f4182d7de073a052dabd3749f20c5aa4ad3e27 gnulib-b81ec69.tar.gz
+f https://mirrors.kernel.org/gnu/texinfo/texinfo-6.7.tar.xz 988403c1542d15ad044600b909997ba3079b10e03224c61188117f3676b02caa
+g git://git.savannah.gnu.org/gnulib.git~b81ec69 _ 1aeea67b7b3883ebcf2b90bc01f4182d7de073a052dabd3749f20c5aa4ad3e27 gnulib-b81ec69.tar.gz

--- a/steps/texinfo-6.7/sources
+++ b/steps/texinfo-6.7/sources
@@ -1,2 +1,2 @@
 f https://mirrors.kernel.org/gnu/texinfo/texinfo-6.7.tar.xz 988403c1542d15ad044600b909997ba3079b10e03224c61188117f3676b02caa
-g git://git.savannah.gnu.org/gnulib.git~b81ec69 _ 1aeea67b7b3883ebcf2b90bc01f4182d7de073a052dabd3749f20c5aa4ad3e27 gnulib-b81ec69.tar.gz
+g https://https.git.savannah.gnu.org/git/gnulib.git~b81ec69 _ 1aeea67b7b3883ebcf2b90bc01f4182d7de073a052dabd3749f20c5aa4ad3e27 gnulib-b81ec69.tar.gz

--- a/steps/util-linux-2.19.1/sources
+++ b/steps/util-linux-2.19.1/sources
@@ -1,1 +1,1 @@
-https://mirrors.kernel.org/pub/linux/utils/util-linux/v2.19/util-linux-2.19.1.tar.xz d12e0f1be0257eadca6a2653acfb4792571c9f7189ed642873363f9b6797bb51
+f https://mirrors.kernel.org/pub/linux/utils/util-linux/v2.19/util-linux-2.19.1.tar.xz d12e0f1be0257eadca6a2653acfb4792571c9f7189ed642873363f9b6797bb51

--- a/steps/which-2.21/sources
+++ b/steps/which-2.21/sources
@@ -1,1 +1,1 @@
-https://carlowood.github.io/which/which-2.21.tar.gz f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad
+f https://carlowood.github.io/which/which-2.21.tar.gz f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad

--- a/steps/xz-5.6.4/sources
+++ b/steps/xz-5.6.4/sources
@@ -1,1 +1,1 @@
-https://github.com/tukaani-project/xz/releases/download/v5.6.4/xz-5.6.4.tar.bz2 176d510c30d80a23b8050bbc048f2ecaacb823ae48b6821727ed6591f0df9200
+f https://github.com/tukaani-project/xz/releases/download/v5.6.4/xz-5.6.4.tar.bz2 176d510c30d80a23b8050bbc048f2ecaacb823ae48b6821727ed6591f0df9200

--- a/steps/zlib-1.2.13/sources
+++ b/steps/zlib-1.2.13/sources
@@ -1,1 +1,1 @@
-https://zlib.net/fossils/zlib-1.2.13.tar.gz b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+f https://zlib.net/fossils/zlib-1.2.13.tar.gz b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30


### PR DESCRIPTION
This really should have been done a while ago. Instead of detecting the type of distfile based on the protocol, explicitly specify it. This allows us to do things like use https:// for git repositories without weird hacks.

(This also fixes the problems with savannah, because it doesn't use the git:// protocol anymore, but https://, which works fine)